### PR TITLE
fix colors updating in rect and circle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Previews http://repo.quamolit.org/phlox/ .
 [![Clojars Project](https://img.shields.io/clojars/v/quamolit/phlox.svg)](https://clojars.org/quamolit/phlox)
 
 ```edn
-[quamolit/phlox "0.1.3"]
+[quamolit/phlox "0.1.4-a1"]
 ```
 
 `render!` to add canvas to `<body/>`:

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1051,53 +1051,30 @@
               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506243766) (:id |LfQNEFP-fO)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506274517) (:text |target) (:id |nNgu_doMX)
-                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526446377) (:text |position) (:id |NeoUTW5Ld)
                   |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526462868) (:text |radius) (:id |HXjq8G3dR)
               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506276751) (:id |Ia_-uVJM4J)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506276751) (:text |if) (:id |8agedUW6s_)
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581526455551)
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581526457002)
                     :data $ {}
-                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506276751) (:id |e6UqiDX3uc)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526454672) (:text |vector?) (:id |mkIyK6zEh7)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526476190) (:text |position) (:id |mAN4Dm8ZPl)
-                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526456277) (:text |and) (:id |yhQC3ojdc)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581526457002)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526458743) (:text |number?) (:id |xc7whWULnleaf)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526460855) (:text |radius) (:id |spm-IDl_)
-                        :id |xc7whWULn
-                    :id |OykY0T4sa
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526458743) (:text |number?) (:id |xc7whWULnleaf)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526460855) (:text |radius) (:id |spm-IDl_)
+                    :id |xc7whWULn
                   |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506276751) (:id |_zxddZKZ5h)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506276751) (:text |.drawCircle) (:id |IsW6ffuMnU)
                       |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506276751) (:text |target) (:id |coM-wvBfhr)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506276751) (:id |Eu1ydAju9g)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506276751) (:text |use-number) (:id |mnbS_K4VQi)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581526478131)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526479607) (:text |first) (:id |eeYEWVBAt)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526483463) (:text |position) (:id |1bm7rqVaD)
-                            :id |QcOSMRBU
-                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506276751) (:id |p8jpZ6GQ4d)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506276751) (:text |use-number) (:id |k-mPW6QaX4)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581526484976)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526485881) (:text |peek) (:id |lWoMwj7kn)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526486962) (:text |position) (:id |FN1zT1Xct)
-                            :id |zaNGQgcks
                       |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506276751) (:id |IsP3h4CRtUV)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506276751) (:text |use-number) (:id |g2RBjl3e_uV)
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526490012) (:text |radius) (:id |VrdzS9s1W)
+                      |q $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381429586) (:text |0) (:id |czMmN4Sc)
+                      |t $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381429995) (:text |0) (:id |oRjRYt0Ks)
                   |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506276751) (:id |YH-hIwl_kTG)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506276751) (:text |js/console.warn) (:id |pzGeYIxkzz5)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506276751) (:text "|\"Unknown options") (:id |UUy9etXl9kT)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526467701) (:text |position) (:id |MrOZVihRRKt)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381314205) (:text "|\"Unknown radius") (:id |UUy9etXl9kT)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381312629) (:text |) (:id |MrOZVihRRKt)
                       |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526469965) (:text |radius) (:id |_BUxf0TSX)
           |init-alpha $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582215601864)
             :data $ {}
@@ -1523,61 +1500,6 @@
                     :id |UmEG6mhAU
                 :id |xFb7gqCk
             :id |2cjwJyEBg
-          |update-line-style $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506085270) (:id |5XsI2U17IP)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506085270) (:text |defn) (:id |7cSfk0M1Xr)
-              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506085270) (:text |update-line-style) (:id |pXDRaYqmC1)
-              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506085270) (:id |6AElpeeDQ3)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506102606) (:text |target) (:id |YiYe9zY0_)
-                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506110366) (:text |line-style) (:id |SiGqW6Jg2Q)
-                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366597347) (:text |line-style0) (:id |evA43Fo9_)
-              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366653557)
-                :data $ {}
-                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506100158) (:id |84osrqKsQ0)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366002007) (:text |if) (:id |VwhMMNpNjt)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506100158) (:id |BE6ieimibk)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |some?) (:id |6q69Jk40fX)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |line-style) (:id |EQVVC30Vp9)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506100158) (:id |-WmUgIgt0r)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |.lineStyle) (:id |iGUHYy6hLA)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |target) (:id |Xb4IQynIAS)
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506100158) (:id |k5e5dfcdxM)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |use-number) (:id |6vH12qGKGF)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506100158) (:id |4T_EnDKaMD)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |:width) (:id |D01kfoFf7_)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |line-style) (:id |yGfL4is7UG)
-                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506100158) (:id |hS8ruMXXXo)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |use-number) (:id |0lBAFwGKEj)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506100158) (:id |EgpVrqrJfhR)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |:color) (:id |7OCZeh6anvA)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |line-style) (:id |hQqiMuagYgU)
-                          |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506100158) (:id |nHmMe034B6J)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |:alpha) (:id |EzBK-eIBXDY)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |line-style) (:id |rkcNu9-Vkap)
-                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506100158) (:id |tSowqpxx)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |.lineStyle) (:id |iGUHYy6hLA)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506100158) (:text |target) (:id |Xb4IQynIAS)
-                          |p $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213901527) (:text |0) (:id |JvC_ZhXsS)
-                          |s $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213902209) (:text |0) (:id |O_0OEePy5)
-                          |t $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213903159) (:text |0) (:id |DnWuBrY8Q)
-                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366654863) (:text |when) (:id |Gzscda0QQ)
-                  |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366655544)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366656245) (:text |not=) (:id |eHpcOqR3)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366658377) (:text |line-style) (:id |uAmh8Fzgu)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366660634) (:text |line-style0) (:id |-y3zqT2VR)
-                    :id |Fj-VxVQpP
-                :id |0CvRCWDiq
           |update-alpha $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574265958635) (:id |1_t_1WYJuj)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574265958635) (:text |defn) (:id |6oNmful9B6)
@@ -2172,44 +2094,19 @@
               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506312618) (:id |bICDbuYR_T)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506340271) (:text |target) (:id |P0U7qxa1FR)
-                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525882870) (:text |position) (:id |rPljm4n1eP)
                   |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525846469) (:text |size) (:id |FIk1NZXeC)
               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506341869) (:id |Ph3txLOC6B)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506341869) (:text |if) (:id |EmGEP-Irol)
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581525865382)
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581525885786)
                     :data $ {}
-                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506341869) (:id |AaY9zcgIVA)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525864399) (:text |vector?) (:id |yrruCVDv7T)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525884962) (:text |position) (:id |tseaqzDkL)
-                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525866931) (:text |and) (:id |-xb6NW6Bf)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581525885786)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525887358) (:text |vector?) (:id |gDqRl3fx1leaf)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525889581) (:text |size) (:id |1l3LOd5t-)
-                        :id |gDqRl3fx1
-                    :id |6zo0Hd3K
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525887358) (:text |vector?) (:id |gDqRl3fx1leaf)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525889581) (:text |size) (:id |1l3LOd5t-)
+                    :id |gDqRl3fx1
                   |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506341869) (:id |qyP0EMGODd)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506341869) (:text |.drawRect) (:id |RHH9N7rJY2)
                       |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506341869) (:text |target) (:id |64aD_A2_5U)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506341869) (:id |-icl564xij)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506341869) (:text |use-number) (:id |IEPXsY1Tr0)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581525892493)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525893773) (:text |first) (:id |-o96o5Td)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525895044) (:text |position) (:id |QBD3Xb-Fd)
-                            :id |5Xs28TDvS
-                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506341869) (:id |BgAmszutO7)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506341869) (:text |use-number) (:id |l2Z9NBU-oLB)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581525896691)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525898546) (:text |peek) (:id |iyAZ6HUVS)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525899821) (:text |position) (:id |7_YFmC8qt)
-                            :id |SytAFrLSm
                       |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506341869) (:id |sujdlNgg20R)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506341869) (:text |use-number) (:id |Vdax_bFHnve)
@@ -2226,11 +2123,12 @@
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525908701) (:text |peek) (:id |lHINNSkOY)
                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525909455) (:text |size) (:id |vDXI0d26c)
                             :id |81JjBtf-
+                      |n $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380857979) (:text |0) (:id |mwLoVC7Ch)
+                      |p $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380858539) (:text |0) (:id |kmM-dCJN)
                   |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506341869) (:id |MtNn_l_T9UP)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506341869) (:text |js/console.warn) (:id |w_-IByueX8J)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506341869) (:text "|\"Unknown options") (:id |K-6djdLszj7)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525871163) (:text |position) (:id |cuBOXUXuR-F)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381118513) (:text "|\"Unknown size") (:id |K-6djdLszj7)
                       |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525987782) (:text |size) (:id |tYbT2YuKN)
         :proc $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574181817878) (:id |MEEfMVkWAO) (:data $ {})
       |phlox.util $ {}
@@ -2896,29 +2794,6 @@
                       |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |ZsbGTqSstkW)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |{}) (:id |bdaJSJJSqQq)
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |iHLIvSNBIzS)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581846138361) (:text |:line-style) (:id |dZJnVNgI6ii)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |TMOfCGoeZHC)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |{}) (:id |iPrOND5oMF8)
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |8rXB0W1zMd8)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |:width) (:id |6Xgs8WCFdkH)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366055755) (:text |4) (:id |KMowR-Bx1zD)
-                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |FZM55WluQfQ)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581848271636) (:text |:color) (:id |O_rjM0H_D-3)
-                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |bareYIkU_5o)
-                                        :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |hslx) (:id |uhqQ-LVRWaW)
-                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |0) (:id |RkUyXsQd49p)
-                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |80) (:id |B37lTuy6khi)
-                                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |50) (:id |HDihFX5Mo6m)
-                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |uLpGBXMjc8Z)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |:alpha) (:id |jRP71y4fuAO)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |1) (:id |h2LZbPgjJKl)
                           |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |-Vu26ylXRqq)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |:on) (:id |Flb9r4R6YjR)
@@ -2940,48 +2815,67 @@
                                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |dispatch!) (:id |eGKY2HJTU-5)
                                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |:add-x) (:id |3vn-HcKS6P2)
                                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503322191) (:text |nil) (:id |9IPHDb6ZYFB)
-                          |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581526678565)
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381515682)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581847431204) (:text |:position) (:id |ymvzlGBuleaf)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581526680735)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381515682) (:text |:line-style) (:id |cMhcnPlrX)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381515682)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526681066) (:text |[]) (:id |WrHYVKCFp)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526682055) (:text |200) (:id |gMG_-mqCO)
-                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526684283) (:text |100) (:id |A698p4O6)
-                                :id |5B-SyxO8z
-                            :id |ymvzlGBu
-                          |p $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581526686570)
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381515682) (:text |{}) (:id |DHHnYHgvE)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381515682)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381515682) (:text |:width) (:id |1dVrN4InM)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381515682) (:text |4) (:id |rIzHPKaNv)
+                                    :id |AGs21fYfQ
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381515682)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381515682) (:text |:color) (:id |GJm6gCHrD)
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381515682)
+                                        :data $ {}
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381515682) (:text |hslx) (:id |-KM6HgTGz)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381515682) (:text |0) (:id |u3Oq2S3eb)
+                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381515682) (:text |80) (:id |s1Cbtl_Bk)
+                                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381515682) (:text |50) (:id |xHE-7UKNY)
+                                        :id |qQx8tadcH
+                                    :id |5RST-RV9R
+                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381515682)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381515682) (:text |:alpha) (:id |Q9lpZiIIjY)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381515682) (:text |1) (:id |O8DLm9PxXO)
+                                    :id |kQqiX1uK_b
+                                :id |IeFaC2hcv
+                            :id |OCfE7EtUn
+                          |u $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381523493)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581849712886) (:text |:radius) (:id |FcVNVW1Yleaf)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526689774) (:text |40) (:id |sJpGEeJI)
-                            :id |FcVNVW1Y
-                          |u $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582214977583)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582214977583) (:text |:fill) (:id |RnENlBnc9)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582214977583)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381523493) (:text |:fill) (:id |9uU2KJLX0)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381523493)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582214977583) (:text |hslx) (:id |gJG0m3fGi)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582214977583) (:text |160) (:id |MMp-FRwnV)
-                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582214977583) (:text |80) (:id |YMPCHh_wB)
-                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366033425) (:text |70) (:id |kg__4PrCE)
-                                :id |-CaKQlfc7
-                            :id |gCmb3hIfi
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381523493) (:text |hslx) (:id |khR7p6Rbr)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381523493) (:text |160) (:id |DlxuCkYtr)
+                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381523493) (:text |80) (:id |MoJl1g1xq)
+                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381523493) (:text |70) (:id |8_9PHSlrW)
+                                :id |3yZyDDPD1
+                            :id |MTTTKPxSw
+                          |e $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381531851)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381531851) (:text |:position) (:id |4se2k8yBA)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381531851)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381531851) (:text |[]) (:id |4DKF8HH5J)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381531851) (:text |200) (:id |J5IpnXDl2)
+                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381531851) (:text |100) (:id |cB8P4o-Lv)
+                                :id |tqHp0uGY9
+                            :id |_7rP0wi7A
+                          |k $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381539525)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381539525) (:text |:radius) (:id |KQP8AJj0S)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381539525) (:text |40) (:id |yzi40uhLN)
+                            :id |oS_s_irkN
                   |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |QTv1p8L-4Mq)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |rect) (:id |GOqL6E1VSVa)
                       |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |iODD8swzSMJ)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |{}) (:id |3Lrm7IIZjCt)
-                          |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581526048762)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526050816) (:text |:position) (:id |tydFVC7xleaf)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581526051104)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526051354) (:text |[]) (:id |fqi_opkzI)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582216075091) (:text |40) (:id |4jh8bqw1M)
-                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582216077006) (:text |40) (:id |kank2ikr)
-                                :id |2HwhYrWQ
-                            :id |tydFVC7x
                           |yT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |WgdqGdDOl1o)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |:pivot) (:id |ienzVmjy8CH)
@@ -3022,50 +2916,71 @@
                                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |dispatch!) (:id |MStGC0L5koW)
                                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |:add-x) (:id |jKdEvIOFFtP)
                                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503324305) (:text |nil) (:id |xc_WmcF5MX9)
-                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |Ba3Hm-XFge-)
+                          |s $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381547729)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |:fill) (:id |LSd29zIMVQ0)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |a7bzpSmlJs_)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381547729) (:text |:line-style) (:id |07-3xUUOI)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381547729)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |hslx) (:id |7hk3EU17ct4)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |200) (:id |6oHSmgMDiN7)
-                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |80) (:id |nZBEC6K_BTA)
-                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |80) (:id |QtlWO8EGoyQ)
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |wZOt4es0nPx)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |:line-style) (:id |6TDsCAOerMX)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |4VuCXGhHP2h)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |{}) (:id |sexQncW64oz)
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |p9t_C1VMo6-)
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381547729) (:text |{}) (:id |E6Nfd268I)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381547729)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |:width) (:id |tHNcqRwWUz-)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366057460) (:text |4) (:id |Z8mfAJ84pb-)
-                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |VNxlgWN_2O3)
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381547729) (:text |:width) (:id |oA5xf7eHG)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381547729) (:text |4) (:id |_Yt16tD2t)
+                                    :id |ASzQBm2aU
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381547729)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |:color) (:id |Eo2yCk9MBRa)
-                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |8pjdTa6Nt1u)
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381547729) (:text |:color) (:id |NrAPHAOd8)
+                                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381547729)
                                         :data $ {}
-                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |hslx) (:id |-j-l0Qbt2KB)
-                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582214535757) (:text |0) (:id |mUpb8_ih-n0)
-                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |80) (:id |spoOjoQHazb)
-                                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366063887) (:text |50) (:id |a8rCUd3Q358)
-                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |v_DxZsAYelo)
+                                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381547729) (:text |hslx) (:id |L7WOpJ6uv)
+                                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381547729) (:text |0) (:id |-phpzz5bv)
+                                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381547729) (:text |80) (:id |FojJQylZu)
+                                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381547729) (:text |50) (:id |qYangZrRi)
+                                        :id |QhfAXJOaC
+                                    :id |3xj5Eesc6
+                                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381547729)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |:alpha) (:id |C32-dKjaKS5)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |1) (:id |Pa4teWHjsqy)
-                          |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |6M976We9hni)
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381547729) (:text |:alpha) (:id |tA_44_n2fR)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381547729) (:text |1) (:id |KaK-sZg7aC)
+                                    :id |n3Um6E4J3R
+                                :id |rYoUrj7sn
+                            :id |4CN1Iq4Rd
+                          |u $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381553821)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |:rotation) (:id |f1NSNgqUzkx)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |VaNTwyr6vK4)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381553821) (:text |:fill) (:id |C_9ijTXCb)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381553821)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |+) (:id |Yohf9DRF_v2)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |1) (:id |wrwUSrWyFzD)
-                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |JkfMKI3l8Xc)
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381553821) (:text |hslx) (:id |lHBjtIfQI)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381553821) (:text |200) (:id |sD2IoVITu)
+                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381553821) (:text |80) (:id |vZjusQLud)
+                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381553821) (:text |80) (:id |uoqJ_X0i5)
+                                :id |qeSfw4S_1
+                            :id |TTfLBbRm4
+                          |xD $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381560398)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381560398) (:text |:rotation) (:id |F9A_aKKm4)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381560398)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381560398) (:text |+) (:id |K4aRGAVnX)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381560398) (:text |1) (:id |7mBlEbZfw)
+                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381560398)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |*) (:id |bOuCfMQXW7Q)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |0.1) (:id |-DVBqK0OM5y)
-                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574354030666) (:text |x) (:id |2K4MeQJUiN)
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381560398) (:text |*) (:id |mvihImxBF)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381560398) (:text |0.1) (:id |UKXalyEIC)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381560398) (:text |x) (:id |BKpz4mJQT)
+                                    :id |-u1_dFr1v
+                                :id |SxDb7Sj7v
+                            :id |KZk5QBEOZ
+                          |e $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381571464)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381571464) (:text |:position) (:id |MfIrCQsVG)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381571464)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381571464) (:text |[]) (:id |TRxRCctp0)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381571464) (:text |40) (:id |tLeHtt8UT)
+                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381571464) (:text |40) (:id |75ShZVX72)
+                                :id |ny8ybO2Sj
+                            :id |XVuKfKYM1
                       |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574353973772) (:id |lhK1YIbA5va)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574353973772) (:text |text) (:id |zRyUN5g8yRV)
@@ -6395,7 +6310,6 @@
                     |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574181875794) (:id |fUmuPVlXAk)
                       :data $ {}
                         |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574181875794) (:text |[]) (:id |3ofV_j7jhe)
-                        |yr $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366745684) (:text |update-line-style) (:id |neuUtQ4_1)
                         |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574181875794) (:text |call-graphics-ops) (:id |wjrokMDFTX)
                         |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366437442) (:text |update-rotation) (:id |BZkWLoLdoU)
                         |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366734554) (:text |update-pivot) (:id |QPTIoYSYSy)
@@ -6587,6 +6501,51 @@
               |u $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573663203882) (:id |1U5mk-Dtm)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573663204296) (:text |let) (:id |1U5mk-Dtmleaf)
+                  |uT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381336155)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381336155) (:text |update-angle) (:id |6G-ANcDq1)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381336155) (:text |target) (:id |QaXLAyTtX)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381336155)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381336155) (:text |:angle) (:id |s6EfuEzYl)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381336155) (:text |props) (:id |fyKFf6VF_)
+                        :id |XZ44-jjcv
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381336155)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381336155) (:text |:angle) (:id |krRjeA1jW)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381336155) (:text |props') (:id |K_gvXFUuj)
+                        :id |U0evaDDMk
+                    :id |6tvH_MtcX
+                  |ur $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381344963)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381344963) (:text |update-pivot) (:id |TmaduINDa)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381344963) (:text |target) (:id |1pgCIK5_w)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381344963)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381344963) (:text |:pivot) (:id |vXu08EhFf)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381344963) (:text |props) (:id |A0gD8nlkS)
+                        :id |H3-Z85KIz
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381344963)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381344963) (:text |:pivot) (:id |MbBg7VBWt)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381344963) (:text |props') (:id |kaEoQBins)
+                        :id |2oZtmilrJ
+                    :id |Ojpa_fUYx
+                  |uj $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381340868)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381340868) (:text |update-rotation) (:id |_aC0wGDDe)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381340868) (:text |target) (:id |lTA8Cy9Fn)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381340868)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381340868) (:text |:rotation) (:id |-d6OzL2th)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381340868) (:text |props) (:id |cznrXUYWG)
+                        :id |sVIM7aU29
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381340868)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381340868) (:text |:rotation) (:id |pG2THkuc3)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381340868) (:text |props') (:id |2gdC58P2f)
+                        :id |uUrwPmk5j
+                    :id |7ODe0qWeM
                   |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573663204502) (:id |5t6dkjI2VW)
                     :data $ {}
                       |D $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573748808143) (:id |ShypYVtRnk)
@@ -6645,57 +6604,51 @@
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526641853) (:text |:radius) (:id |RoeoAgVkqi)
                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526634067) (:text |props') (:id |3baO1pyfJJ)
+                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574503157848) (:id |I0959owa8)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503158696) (:text |update-events) (:id |I0959owa8leaf)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503162970) (:text |target) (:id |A8AwvKgJM)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574503727736) (:id |R7TnL4hyTn)
+                        :data $ {}
+                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503871457) (:text |->) (:id |qCYIoVy7IR)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503163750) (:text |element) (:id |YDdNCa-Qqv)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503873203) (:text |:props) (:id |-B9DIVAj7n)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503873796) (:text |:on) (:id |vBvjW2hndY)
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574503750462) (:id |EUKP3lL9eb)
+                        :data $ {}
+                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503875827) (:text |->) (:id |E2CKpn29n)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503165383) (:text |old-element) (:id |7J6eKdPpJh)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503877398) (:text |:props) (:id |8oKxNB3th)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503878749) (:text |:on) (:id |bE0wQud7ZZ)
+                      |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503166913) (:text |dispatch!) (:id |weAsRrbQN0)
+                  |t $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381327065)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381327065) (:text |update-position) (:id |qXFOi6T7Y)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381327065) (:text |target) (:id |73gPtfIgd)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381327065)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381327065) (:text |:position) (:id |xDDLM4BW2)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381327065) (:text |props) (:id |f4Cj0lch5)
+                        :id |IJ2E2kOkB
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381327065)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381327065) (:text |:position) (:id |ivZZvpNIl)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381327065) (:text |props') (:id |nwE2pqfLE)
+                        :id |vy7-Bbj-2
+                    :id |8TVg9h8zC
                   |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573663217166) (:id |8Wa8EV6qy5)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573663225993) (:text |when) (:id |8Wa8EV6qy5leaf)
-                      |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573748912461) (:id |l5Lm7pABJF)
+                      |q $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381194618)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748912461) (:text |when) (:id |sNrOe9-gC8)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573748912461) (:id |JYr3nYdzul)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381196162) (:text |init-fill) (:id |HXJ0_0P4leaf)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381200580) (:text |target) (:id |ckPSShG6)
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381201503)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748912461) (:text |some?) (:id |-iabB6GGka)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573748912461) (:id |GCSMHG1pXk)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748912461) (:text |:fill) (:id |nAEUn52C3U)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748912461) (:text |props) (:id |f_4QNo2FRH)
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573748912461) (:id |EOo1QNnsxj)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748912461) (:text |.beginFill) (:id |BoYF_5wbln)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574008730691) (:text |target) (:id |-zie9-mKdQ)
-                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573748912461) (:id |VPCUuY0y5Z)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748912461) (:text |:fill) (:id |-SnORc103A)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748912461) (:text |props) (:id |9_wJNp_yi6)
-                      |yr $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582213534100)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366504382) (:text |update-pivot) (:id |BrTl00VOj)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213534100) (:text |target) (:id |LymMl5xCF)
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582213534100)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213534100) (:text |:pivot) (:id |JCKSIq4Dh)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213534100) (:text |props) (:id |eWVTmJYdg7)
-                            :id |GRvUpTvKp
-                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366507293)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366507293) (:text |:pivot) (:id |4rVW9kW4X)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366507293) (:text |props') (:id |3rJ-9_6aI)
-                            :id |4SZFaW4WL
-                        :id |8LES4LTCm
-                      |yT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582213511842)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366379231) (:text |update-angle) (:id |HjLjnpJl5)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213511842) (:text |target) (:id |qLKP9z24B)
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582213511842)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213511842) (:text |:angle) (:id |ACkNK7wNOP)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213511842) (:text |props) (:id |oA4gB-HxDT)
-                            :id |yRicrlUYW
-                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366373299)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366373299) (:text |:angle) (:id |31z6kXkf0)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366373299) (:text |props') (:id |ieomDwuDl)
-                            :id |3W83wvVih
-                        :id |JJM84IVvW
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381204295) (:text |:fill) (:id |mraoSqWAR)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381205078) (:text |props) (:id |QgvE3FGsC)
+                            :id |pBQrSgH4
+                        :id |HXJ0_0P4
                       |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573748754190) (:id |-0RUH-nfTH)
                         :data $ {}
                           |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748755519) (:text |or) (:id |pEp4k5dAnN)
@@ -6726,85 +6679,39 @@
                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526625111) (:text |radius) (:id |NdHVVPo9)
                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526627496) (:text |radius') (:id |op-XlPlUb)
                             :id |bLDWe47p
-                      |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573748937309) (:id |0rtg_fZhjg)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748937309) (:text |when) (:id |TimlBzVGXE)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573748937309) (:id |XlS5bQF2bi)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748937309) (:text |some?) (:id |svadR5Uhfr)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573748937309) (:id |rHbHxEHj7H)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748937309) (:text |:fill) (:id |2KgOGfBQV3)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748937309) (:text |props) (:id |B8GhlQeuNn)
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573748937309) (:id |9kQhnTvYfm)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748937309) (:text |.endFill) (:id |JOKcuFEpbJ)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574008735099) (:text |target) (:id |fspPvHYo6k)
-                      |yj $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582213528340)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366414150) (:text |update-rotation) (:id |Gi0uCNkv0)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213528340) (:text |target) (:id |ooqZPjETv)
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582213528340)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213528340) (:text |:rotation) (:id |f-XbWdyyW)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213528340) (:text |props) (:id |veau_3pyw2)
-                            :id |m_HbCXXYb
-                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582213528340)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213528340) (:text |:rotation) (:id |f-XbWdyyW)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366457466) (:text |props') (:id |veau_3pyw2)
-                            :id |ZxPz1FF5n
-                        :id |xtDnk0JWr
-                      |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574266726636) (:id |IKfHNESkr)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366335884) (:text |update-alpha) (:id |IKfHNESkrleaf)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574266730023) (:text |target) (:id |fzQBtAXFVa)
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574266730221) (:id |gweoyswU_X)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574266732549) (:text |:alpha) (:id |Ija3rpk9_u)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574266733249) (:text |props) (:id |Su9TfHe-dG)
-                          |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366340462)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366340462) (:text |:alpha) (:id |H1shngvFX)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366340462) (:text |props') (:id |9YH6UGLgM)
-                            :id |gjuPQSZ6N
                       |l $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573748914918) (:id |OjB_t0E6oX)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748916418) (:text |.clear) (:id |OjB_t0E6oXleaf)
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574008729320) (:text |target) (:id |OJiJKn6CR)
                       |u $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506170400) (:id |woGzFxlU2z)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366722537) (:text |update-line-style) (:id |woGzFxlU2zleaf)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381209570) (:text |init-line-style) (:id |woGzFxlU2zleaf)
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506176117) (:text |target) (:id |92FPE8PsI)
                           |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506177375) (:text |line-style) (:id |_qjkuwsM2h)
-                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366710873) (:text |line-style') (:id |6QByPfrM)
                       |wT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506252767) (:id |gkqo3JEzt)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506255984) (:text |draw-circle) (:id |gkqo3JEztleaf)
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506259152) (:text |target) (:id |Ot9gcr1eO)
-                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526590886) (:text |position) (:id |ZF5T5mrUV3)
                           |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581526598651)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526600450) (:text |:radius) (:id |UF-8gflWw)
                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526603106) (:text |props) (:id |uZybhqtT)
                             :id |tTw5e2vuM
-                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574503157848) (:id |I0959owa8)
+                  |u $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381331681)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503158696) (:text |update-events) (:id |I0959owa8leaf)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503162970) (:text |target) (:id |A8AwvKgJM)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574503727736) (:id |R7TnL4hyTn)
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381331681) (:text |update-alpha) (:id |kQG0yVGSx)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381331681) (:text |target) (:id |r7ev1C3EU)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381331681)
                         :data $ {}
-                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503871457) (:text |->) (:id |qCYIoVy7IR)
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503163750) (:text |element) (:id |YDdNCa-Qqv)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503873203) (:text |:props) (:id |-B9DIVAj7n)
-                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503873796) (:text |:on) (:id |vBvjW2hndY)
-                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574503750462) (:id |EUKP3lL9eb)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381331681) (:text |:alpha) (:id |ajkEIvn5B)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381331681) (:text |props) (:id |PVI9k_WkN)
+                        :id |ZlhWnGmEL
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381331681)
                         :data $ {}
-                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503875827) (:text |->) (:id |E2CKpn29n)
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503165383) (:text |old-element) (:id |7J6eKdPpJh)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503877398) (:text |:props) (:id |8oKxNB3th)
-                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503878749) (:text |:on) (:id |bE0wQud7ZZ)
-                      |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503166913) (:text |dispatch!) (:id |weAsRrbQN0)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381331681) (:text |:alpha) (:id |0gKCzBwtV)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381331681) (:text |props') (:id |FqTT-dvl3)
+                        :id |F420XS_FN
+                    :id |wuKj1q2yS
           |render-rect $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371747292) (:id |7s1e17Tdje)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371747292) (:text |defn) (:id |S2GV9g8trw)
@@ -6820,7 +6727,11 @@
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582367175855) (:text |init-line-style) (:id |2qKN1q9dhleaf)
                       |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506157297) (:text |target) (:id |lerHPhAT-)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506158636) (:text |line-style) (:id |ud6xLtX1gm)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380949145)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380949145) (:text |:line-style) (:id |unVvEIjQ1)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380949145) (:text |props) (:id |6HmcNP-cI)
+                        :id |iWk5oTtI4
                   |y9 $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574182731175) (:id |8tSBcGUzF)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582215918211) (:text |init-pivot) (:id |8tSBcGUzFleaf)
@@ -6849,13 +6760,6 @@
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |:props) (:id |DSragQUDqz)
                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |element) (:id |d0oA0J-HZEl)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371753475) (:id |ksYpIS5GJzx)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |line-style) (:id |fDOdE30vppo)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371753475) (:id |x88YU_5JU5P)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |:line-style) (:id |5kAxuIch9MC)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |props) (:id |BebjiijbxLd)
                       |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573384965918) (:id |PZuCba8cDP)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573384966973) (:text |events) (:id |PZuCba8cDPleaf)
@@ -6879,6 +6783,26 @@
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213455657) (:text |props) (:id |LMnXiT76X)
                         :id |nUcn5N2Jb
                     :id |tYg8KLNA4
+                  |t $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380908811)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380911685) (:text |init-fill) (:id |dqXGOM7uleaf)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380913476) (:text |target) (:id |CHC_qkwz)
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380920998)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380915840) (:text |props) (:id |ExBkEKHRs)
+                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380922203) (:text |:fill) (:id |Sfa-aJL2)
+                        :id |YmxgQ9fZ7
+                    :id |dqXGOM7u
+                  |w8 $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381163382)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381163382) (:text |draw-rect) (:id |1C5nUihuT)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381163382) (:text |target) (:id |9fCKmGQw4)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381163382)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381163382) (:text |:size) (:id |v35dtbj5c)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381163382) (:text |props) (:id |_ZfOcu5sw)
+                        :id |Wagawqhmc
+                    :id |GzyeijXSa
                   |yC $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574182840454) (:id |pQE97xYm7)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582215920863) (:text |init-alpha) (:id |N42AsWVuJ6leaf)
@@ -6887,38 +6811,16 @@
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574266819493) (:text |:alpha) (:id |pVuY-P2wDV)
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574182847893) (:text |props) (:id |-cR76fLWUX)
-                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371753475) (:id |imnsWDLyubC)
+                  |x8T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381166643)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |if) (:id |80KMK2Z8eg8)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371753475) (:id |a-aybmZdQhb)
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381170389) (:text |init-position) (:id |ulsXviW03)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381166643) (:text |target) (:id |ABlyX_uVT)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381166643)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |some?) (:id |PslsvsGJczp)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371753475) (:id |KkLr5AiFb6p)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |:fill) (:id |j17rLc1UQCC)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |props) (:id |sTFFNnWueXs)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371753475) (:id |7_V3zEw1Fg1)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |.beginFill) (:id |rYy-nSv2nsD)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574008648497) (:text |target) (:id |YnCN7Wthman)
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371753475) (:id |y6h-GAkfQ_l)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |:fill) (:id |0z2lpCGCMbn)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |props) (:id |tPfwST0VDqz)
-                  |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371753475) (:id |gyBgO1rnNNN)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |if) (:id |rhD-mS5C7Tn)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371753475) (:id |QmJ--zudEBq)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |some?) (:id |_aw7ZwXgtFL)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371753475) (:id |OsOUwk_fHOU)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |:fill) (:id |vWa6asC7WfV)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |props) (:id |YyjND1zaSbn)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371753475) (:id |nVm4s1plD1t)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371753475) (:text |.endFill) (:id |sB1pyhbiVAW)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574008653575) (:text |target) (:id |J1Udb0EnZh5)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381166643) (:text |:position) (:id |p4gCBLVal)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381166643) (:text |props) (:id |Ts6koy2F0)
+                        :id |r2T5ZsK91
+                    :id |uWjcs2Ld0
                   |yP $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506528485) (:id |4eiEyNULMe)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506533752) (:text |render-children) (:id |4eiEyNULMeleaf)
@@ -6936,20 +6838,6 @@
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574182847893) (:text |:rotation) (:id |pVuY-P2wDV)
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574182847893) (:text |props) (:id |-cR76fLWUX)
-                  |xT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506357834) (:id |GIwmD-U9b0)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506361222) (:text |draw-rect) (:id |GIwmD-U9b0leaf)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506365102) (:text |target) (:id |l_PgLET2k)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581525832906)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525833572) (:text |:position) (:id |sMFGZ0e8dh)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525836301) (:text |props) (:id |Qa0K4miA)
-                        :id |ap7OJsO-a
-                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581525836866)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525837726) (:text |:size) (:id |0bbpHuG4zleaf)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525838423) (:text |props) (:id |hfOekYxOS)
-                        :id |0bbpHuG4z
           |render-container $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573372747089) (:id |_fO-QVMRjT)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573372747089) (:text |defn) (:id |i3zmFyiwCc)
@@ -7195,25 +7083,20 @@
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582213435814) (:text |props) (:id |fAj6wkPyE)
                         :id |0SYm5chaO
                     :id |GQfcRjY_8
-                  |q $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371715536) (:id |fbXZsQkHcE)
+                  |qG $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381417067)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748900009) (:text |when) (:id |o2EUlY__Bv)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371715536) (:id |rloT47mudn)
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381419580) (:text |init-position) (:id |tnR6bdIgL)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381417067) (:text |target) (:id |Y47Vqov0R)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381417067)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371715536) (:text |some?) (:id |UgT18J23l-)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371715536) (:id |kY8qVGjBr-)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371715536) (:text |:fill) (:id |XinjU3TjHr)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371715536) (:text |props) (:id |LVMUwZFc81)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573371715536) (:id |FkGc1enuZ8)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573371719671) (:text |.endFill) (:id |m-upxTL2FP)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574008629421) (:text |target) (:id |_S_hIqGKvV)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381423646) (:text |:position) (:id |RikEry5Pu)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381417067) (:text |props) (:id |epxQwml3R)
+                        :id |xoQkdZOGT
+                    :id |ZYLmVVXIQ
                   |pT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506294446) (:id |anBa5KBn9)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506297688) (:text |draw-circle) (:id |anBa5KBn9leaf)
                       |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506299046) (:text |target) (:id |r-x7d973Nm)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526515131) (:text |position) (:id |F_K96npW4g)
                       |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581526550872)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581526551520) (:text |:radius) (:id |e6Er92pom)
@@ -7289,24 +7172,6 @@
                         :id |UCPnxtcQU
                     :id |jyy4lv3SZ
                   |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574008635997) (:text |target) (:id |_ot7SQ51I8)
-                  |l $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573369846208) (:id |a5fVJMLfro)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573748897452) (:text |when) (:id |a5fVJMLfroleaf)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573369858726) (:id |oMXM-Soqvw)
-                        :data $ {}
-                          |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573369862005) (:text |some?) (:id |aXVpCFdOvR)
-                          |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573369847476) (:id |FPct7EQjtB)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573369851536) (:text |:fill) (:id |9YbXNRuAVn)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573369855699) (:text |props) (:id |fxB3nPH04)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573369862871) (:id |3Wd0JJFpkl)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573369871943) (:text |.beginFill) (:id |3Wd0JJFpklleaf)
-                          |b $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574008625552) (:text |target) (:id |qLRTpy3MBP)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573369872828) (:id |k7Q3lhRGXN)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573369873488) (:text |:fill) (:id |UfMw8iKE0)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573369874404) (:text |props) (:id |buNVeib2y)
                   |qf $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574266782735) (:id |kFB3Fgxqv)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582215913551) (:text |init-alpha) (:id |kFB3Fgxqvleaf)
@@ -7315,6 +7180,16 @@
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574266788275) (:text |:alpha) (:id |00K7om7Kfu)
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574266788938) (:text |props) (:id |SbPmytWiZf)
+                  |m $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381361696)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381363948) (:text |init-fill) (:id |muO2zKQCZleaf)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381364918) (:text |target) (:id |pES1yLae)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381365090)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381365814) (:text |:fill) (:id |7pDZtjIox)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381366359) (:text |props) (:id |WMJdwBhv_)
+                        :id |f4hoIg78
+                    :id |muO2zKQCZ
                   |qD $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574502772367) (:id |4_ry-8sw-)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582215489048) (:text |init-events) (:id |4_ry-8sw-leaf)
@@ -7490,7 +7365,6 @@
                   |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503189729) (:text |dispatch!) (:id |qdoJkIuo4f)
               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749473476) (:id |-lT6oJfHt6)
                 :data $ {}
-                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749474217) (:text |let) (:id |n3PYpVJds)
                   |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749475467) (:id |Y0VhEOBa4W)
                     :data $ {}
                       |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749475467) (:id |Fir64pJ0sU)
@@ -7549,17 +7423,59 @@
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525948831) (:text |:size) (:id |KNxBOyuDO4I)
                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749475467) (:text |props') (:id |QmXb_vOp34i)
+                  |w $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366944190)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366944190) (:text |update-angle) (:id |JJOUC9-0-)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366944190) (:text |target) (:id |2YUQ2cLVs)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366944190)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366944190) (:text |:angle) (:id |tz7d-zlBV)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366944190) (:text |props) (:id |Rqjgu874J)
+                        :id |jtNC4mQpm
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366944190)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366944190) (:text |:angle) (:id |l4GqVguLL)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366944190) (:text |props') (:id |tnPPNeWeJ)
+                        :id |GiPAbIvFk
+                    :id |a6Qd1Xgy0
+                  |yT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574503758934) (:id |ke5Jw8GOuv)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503758934) (:text |update-events) (:id |-c1Lh_Jm3D)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503758934) (:text |target) (:id |sHbaVAcnll)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574503758934) (:id |HVRll6Bpbq)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503851903) (:text |->) (:id |J3UDKHyLj3)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503853446) (:text |element) (:id |2vG_pB8BTF)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503854582) (:text |:props) (:id |8OoarK6bW)
+                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503857632) (:text |:on) (:id |P5tjKvYl1I)
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574503859081) (:id |sA85G4Lchg)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503859081) (:text |->) (:id |wl9hn0HM3d)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503862757) (:text |old-element) (:id |A1u6IgPnXa)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503859081) (:text |:props) (:id |9ieYolb6Fi)
+                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503859081) (:text |:on) (:id |Al2NCbT8Dc)
+                      |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503758934) (:text |dispatch!) (:id |pABdXJWDcx)
+                  |p $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380759978)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380759978) (:text |update-position) (:id |fr2xGLuel)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380759978) (:text |target) (:id |8DChowyeB)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380759978)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380759978) (:text |:position) (:id |77pAnnqUI)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380759978) (:text |props) (:id |Ognt_LZP8)
+                        :id |d22AFLBGR
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380759978)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380759978) (:text |:position) (:id |6LkS8HiUx)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380759978) (:text |props') (:id |37h3kk5D1)
+                        :id |7pmTk42R4
+                    :id |NPC4on6Tt
                   |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749491725) (:id |tKi882tAv)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749492371) (:text |when) (:id |tKi882tAvleaf)
                       |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749492842) (:id |7tpHs_EaO8)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749492842) (:text |or) (:id |r8xsuFe9S_)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749492842) (:id |kp3_DGqROw)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749492842) (:text |not=) (:id |cgpMIqyzt_)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525957605) (:text |position) (:id |7VF-dgHP1y)
-                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525960170) (:text |position') (:id |l1OJTB4Rr9)
                           |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749492842) (:id |vrTmMU60gP)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749492842) (:text |not=) (:id |mJaE1F0nSw)
@@ -7586,65 +7502,26 @@
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573981656499) (:text |.clear) (:id |OM6SDqJ8Ileaf)
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574008743761) (:text |target) (:id |p6vd9Vysg)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749517689) (:id |xMVY7FWZLc)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749517689) (:text |if) (:id |s1gQxHoyvO)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749517689) (:id |LwXkFozKJm)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749517689) (:text |some?) (:id |YVj62TTrUR)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749517689) (:id |4t3cp342Gy)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749517689) (:text |:fill) (:id |AOIqJLA20e)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749517689) (:text |props) (:id |hc7nzRKqm5)
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749517689) (:id |hIiX5Bd2sV)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749517689) (:text |.beginFill) (:id |vrov9LgBYD)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574008744677) (:text |target) (:id |qIhn3EpS8Z)
-                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749517689) (:id |hCOltihA8T)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749517689) (:text |:fill) (:id |bdiwTqncy-)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749517689) (:text |props) (:id |kl0GYcXc_A)
                       |w $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506184235) (:id |TYeHmnd8jq)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366966456) (:text |update-line-style) (:id |TYeHmnd8jqleaf)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381013746) (:text |init-line-style) (:id |TYeHmnd8jqleaf)
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506191285) (:text |target) (:id |S3ZVac5kuN)
                           |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506193485) (:text |line-style) (:id |4sGAMfwC5d)
-                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366962773) (:text |line-style') (:id |omX-MD8uU)
                       |xT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574506326785) (:id |nvQstbC6X)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506331338) (:text |draw-rect) (:id |nvQstbC6Xleaf)
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574506333077) (:text |target) (:id |96aJFjKezJ)
-                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525972119) (:text |position) (:id |2G8yFb1NlN)
                           |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581525972868) (:text |size) (:id |qR_64IIlo)
-                      |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749530166) (:id |KgpivGJf_2)
+                      |p $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380959720)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749530166) (:text |if) (:id |7m6qM8yucI)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749530166) (:id |56mr7MlQNU)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380959720) (:text |init-fill) (:id |3Mb77LnK7)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380959720) (:text |target) (:id |6g7YRvELz)
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380959720)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749530166) (:text |some?) (:id |yuvCAXjZGP)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749530166) (:id |7rN24c39mU)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749530166) (:text |:fill) (:id |VS5rmExKeu)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749530166) (:text |props) (:id |N4WKtkMYaV)
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573749530166) (:id |WrZu81WP5z)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749530166) (:text |.endFill) (:id |kE44FSE8MU)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574008749624) (:text |target) (:id |ieTTdYCSf_)
-                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366954514)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366954514) (:text |update-rotation) (:id |V45cYTYOq)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366954514) (:text |target) (:id |99vuCLaFm)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366954514)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366954514) (:text |:rotation) (:id |H2Nfg6_Rc)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366954514) (:text |props) (:id |jgvUkrWf1)
-                        :id |Wo-IRFqdW
-                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366954514)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366954514) (:text |:rotation) (:id |HiPwvCOc_)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366954514) (:text |props') (:id |z4p1jpC36)
-                        :id |QYZwVVMSI
-                    :id |GWt0o7RzQ
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380959720) (:text |:fill) (:id |4xncCXnfY)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380959720) (:text |props) (:id |WyufXxhAD)
+                            :id |C9hiwFNyU
+                        :id |hwMDwsUQg
                   |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366935702)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366935702) (:text |update-pivot) (:id |SQ__e5omP)
@@ -7660,6 +7537,21 @@
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366935702) (:text |props') (:id |uBYNzr00u)
                         :id |JfQIauT_e
                     :id |tR-dQlqUe
+                  |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366954514)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366954514) (:text |update-rotation) (:id |V45cYTYOq)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366954514) (:text |target) (:id |99vuCLaFm)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366954514)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366954514) (:text |:rotation) (:id |H2Nfg6_Rc)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366954514) (:text |props) (:id |jgvUkrWf1)
+                        :id |Wo-IRFqdW
+                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366954514)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366954514) (:text |:rotation) (:id |HiPwvCOc_)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366954514) (:text |props') (:id |z4p1jpC36)
+                        :id |QYZwVVMSI
+                    :id |GWt0o7RzQ
                   |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366929621)
                     :data $ {}
                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366929621) (:text |update-alpha) (:id |gUm1-o_ot)
@@ -7675,38 +7567,7 @@
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366929621) (:text |props') (:id |XXBBzSh1d)
                         :id |0E2Kkhw3_
                     :id |JDwpOvtaW
-                  |yT $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574503758934) (:id |ke5Jw8GOuv)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503758934) (:text |update-events) (:id |-c1Lh_Jm3D)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503758934) (:text |target) (:id |sHbaVAcnll)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574503758934) (:id |HVRll6Bpbq)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503851903) (:text |->) (:id |J3UDKHyLj3)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503853446) (:text |element) (:id |2vG_pB8BTF)
-                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503854582) (:text |:props) (:id |8OoarK6bW)
-                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503857632) (:text |:on) (:id |P5tjKvYl1I)
-                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574503859081) (:id |sA85G4Lchg)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503859081) (:text |->) (:id |wl9hn0HM3d)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503862757) (:text |old-element) (:id |A1u6IgPnXa)
-                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503859081) (:text |:props) (:id |9ieYolb6Fi)
-                          |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503859081) (:text |:on) (:id |Al2NCbT8Dc)
-                      |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574503758934) (:text |dispatch!) (:id |pABdXJWDcx)
-                  |w $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366944190)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366944190) (:text |update-angle) (:id |JJOUC9-0-)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366944190) (:text |target) (:id |2YUQ2cLVs)
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366944190)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366944190) (:text |:angle) (:id |tz7d-zlBV)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366944190) (:text |props) (:id |Rqjgu874J)
-                        :id |jtNC4mQpm
-                      |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582366944190)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366944190) (:text |:angle) (:id |l4GqVguLL)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366944190) (:text |props') (:id |tnPPNeWeJ)
-                        :id |GiPAbIvFk
-                    :id |a6Qd1Xgy0
+                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573749474217) (:text |let) (:id |n3PYpVJds)
           |update-container $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573661626513) (:id |gsp-MnuD0u)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573661626513) (:text |defn) (:id |JLfCAb1WK-)
@@ -7810,6 +7671,36 @@
                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582366895657) (:text |props') (:id |nJHEqD3lv)
                         :id |sIMeg3xh7
                     :id |N6gW0WVqY
+          |init-fill $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380924731)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380924731) (:text |defn) (:id |Ya0b9aIdt)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380924731) (:text |init-fill) (:id |cz-Zy09V0)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380924731)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380924731) (:text |target) (:id |0_EkXIDh6)
+                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380929547) (:text |color) (:id |MV1o-wwxC)
+                :id |IXntjaZTZ
+              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380930315)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380930315) (:text |if) (:id |5CkoNvyrq)
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380930315)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380930315) (:text |some?) (:id |V7z_ynS8l)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380933269) (:text |color) (:id |dnI8BCXiQ)
+                    :id |3w3KD2Ost
+                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582380930315)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380930315) (:text |.beginFill) (:id |oeWvvT52A)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380930315) (:text |target) (:id |ybWXiZ6Uo)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582380936362) (:text |color) (:id |1UakO8pcX)
+                    :id |FhyMbtoD8
+                :id |LhoRFtwiT
+              |t $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1582381285904)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381290828) (:text |.endFill) (:id |GZrNsL7tlleaf)
+                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1582381289847) (:text |target) (:id |PfUYDXnR1)
+                :id |GZrNsL7tl
+            :id |GHWINd-UP
           |in-dev? $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1581004810881)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581004810881) (:text |def) (:id |mREI5Xs3_)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>quamolit</groupId>
   <artifactId>phlox</artifactId>
-  <version>0.1.3</version>
+  <version>0.1.4-a2</version>
   <name>phlox</name>
 
   <url>https://github.com/Quamolit/phlox</url>

--- a/src/phlox/render/draw.cljs
+++ b/src/phlox/render/draw.cljs
@@ -62,24 +62,15 @@
       :end-hole (.endHole target)
       (js/console.warn "not supported:" op))))
 
-(defn draw-circle [target position radius]
-  (if (and (vector? position) (number? radius))
-    (.drawCircle
-     target
-     (use-number (first position))
-     (use-number (peek position))
-     (use-number radius))
-    (js/console.warn "Unknown options" position radius)))
+(defn draw-circle [target radius]
+  (if (number? radius)
+    (.drawCircle target 0 0 (use-number radius))
+    (js/console.warn "Unknown radius"  radius)))
 
-(defn draw-rect [target position size]
-  (if (and (vector? position) (vector? size))
-    (.drawRect
-     target
-     (use-number (first position))
-     (use-number (peek position))
-     (use-number (first size))
-     (use-number (peek size)))
-    (js/console.warn "Unknown options" position size)))
+(defn draw-rect [target size]
+  (if (vector? size)
+    (.drawRect target 0 0 (use-number (first size)) (use-number (peek size)))
+    (js/console.warn "Unknown size" size)))
 
 (defn init-alpha [target alpha] (when (some? alpha) (set! (-> target .-alpha) alpha)))
 
@@ -122,16 +113,6 @@
   (if (some? events)
     (do (set! (.-buttonMode target) true) (set! (.-interactive target) true))
     (do (set! (.-buttonMode target) false) (set! (.-interactive target) false))))
-
-(defn update-line-style [target line-style line-style0]
-  (when (not= line-style line-style0)
-    (if (some? line-style)
-      (.lineStyle
-       target
-       (use-number (:width line-style))
-       (use-number (:color line-style))
-       (:alpha line-style))
-      (.lineStyle target 0 0 0))))
 
 (defn update-pivot [target pivot pivot0]
   (when (not= pivot pivot0)


### PR DESCRIPTION
Updating `:fill` or `:line-style` might accidentally reset other styles. Fixed but refactoring related methods.