### PR TITLE
provide a simpler way declaring states tree; breaking release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Previews http://repo.quamolit.org/phlox/ .
 ```clojure
 (ns app.main
   (:require [phlox.core :refer [defcomp hslx render! create-list
-                                rect circle text container graphics]]))
+                                rect circle text container graphics >>]]))
 
 (defcomp comp-demo [data]
   (rect
@@ -187,9 +187,7 @@ Draw graphics(use `phlox.core/g` for validations):
 `phlox.comp.slider/comp-slider` provides a little slider bar of a number, changes on dragging:
 
 ```clojure
-(comp-slider
- (conj cursor :c)
- (:c states)
+(comp-slider (>> states :c)
  {:value (:c state),
   :unit 10,
   :min 1
@@ -204,9 +202,7 @@ Draw graphics(use `phlox.core/g` for validations):
 `phlox.comp.drag-point/comp-dragging-point` provides a point for dragging:
 
 ```clojure
-(comp-drag-point
- (conj cursor :p3)
- (:p3 states)
+(comp-drag-point (>> states :p3)
  {:position (:p3 state),
   :unit 0.4,
   :title "DEMO"

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -2872,6 +2872,7 @@
                     |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573356355436) (:id |wt5cup8kOO)
                       :data $ {}
                         |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573356356578) (:text |[]) (:id |QV31dWY5iW)
+                        |yr $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639017252) (:text |>>) (:id |nmU09G6Q7c)
                         |s $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581850032842) (:text |g) (:id |p6bybKMg)
                         |yT $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573974254119) (:text |container) (:id |_pYCrKPUDN)
                         |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573974179009) (:text |circle) (:id |YXhIPtW-10)
@@ -3118,7 +3119,6 @@
               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040769018) (:text |comp-points-demo) (:id |MnMiH4Mat)
               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583040769018)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040774618) (:text |cursor) (:id |G5m1kR1w)
                   |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040775468) (:text |states) (:id |h1332GVRQ)
                 :id |HvAbtHOUd
               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583040776938)
@@ -3183,6 +3183,15 @@
                                 :id |YoNjmWP2r
                             :id |Q-WQyrh2r
                         :id |FoM-3kUvF
+                      |D $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639088520)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639090173) (:text |cursor) (:id |guY-9z8qwtleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639090500)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639093099) (:text |:cursor) (:id |yak2xlc-65)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639093785) (:text |states) (:id |6JNXFq9_yB)
+                            :id |R_BKY2SVfV
+                        :id |guY-9z8qwt
                     :id |V7YS969_J
                   |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042592169)
                     :data $ {}
@@ -3191,15 +3200,10 @@
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040806389) (:text |comp-drag-point) (:id |0aWSJetgMleaf)
                           |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583040808317)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040807969) (:text |cursor) (:id |d4K6zATEc)
-                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040809173) (:text |conj) (:id |minF1zw9g)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639310919) (:text |states) (:id |d4K6zATEc)
+                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639309369) (:text |>>) (:id |minF1zw9g)
                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040812518) (:text |:p1) (:id |pdJl94Gz2)
                             :id |3BvbVkTu
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583040813616)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040815854) (:text |:p1) (:id |H3YiKq1w)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040816745) (:text |states) (:id |nLd9klC8)
-                            :id |L1s6DHbxY
                           |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583040819621)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040820084) (:text |{}) (:id |mlS0RnD4)
@@ -3259,15 +3263,10 @@
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042619932) (:text |comp-drag-point) (:id |AVvIfMrHC)
                           |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042619932)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042619932) (:text |conj) (:id |vrd3ibFyt)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042619932) (:text |cursor) (:id |MBLqVVLKn)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639303849) (:text |>>) (:id |vrd3ibFyt)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639305671) (:text |states) (:id |MBLqVVLKn)
                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042619932) (:text |:p2) (:id |2I-e15hBS)
                             :id |z_Df-EIqr
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042619932)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042619932) (:text |:p2) (:id |KbaovJx-k)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042619932) (:text |states) (:id |7Ioln6RT2)
-                            :id |kzxA0HtB8
                           |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042619932)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042619932) (:text |{}) (:id |7Sqlcnxkb)
@@ -3317,15 +3316,10 @@
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |comp-drag-point) (:id |EGuLcfL7F)
                           |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042624042)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |conj) (:id |DI8ODEAEu)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |cursor) (:id |zi5Vm-onl)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639316977) (:text |>>) (:id |DI8ODEAEu)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639318415) (:text |states) (:id |zi5Vm-onl)
                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |:p3) (:id |zyij6wKiJ)
                             :id |rilnZj9Ah
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042624042)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |:p3) (:id |BCFU7cmLz)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |states) (:id |sxh6qQ2ma)
-                            :id |1CtHbNvk1
                           |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042624042)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |{}) (:id |_E7w39vZe)
@@ -3402,15 +3396,10 @@
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |comp-drag-point) (:id |EGuLcfL7F)
                           |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042624042)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |conj) (:id |DI8ODEAEu)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |cursor) (:id |zi5Vm-onl)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639322825) (:text |>>) (:id |DI8ODEAEu)
                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |:p4) (:id |zyij6wKiJ)
+                              |f $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639323953) (:text |states) (:id |zVdC7nS_h)
                             :id |rilnZj9Ah
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042624042)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |:p4) (:id |BCFU7cmLz)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |states) (:id |sxh6qQ2ma)
-                            :id |1CtHbNvk1
                           |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042624042)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042624042) (:text |{}) (:id |_E7w39vZe)
@@ -4089,17 +4078,12 @@
                               |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583553174174)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583553180010) (:text |comp-switch-demo) (:id |_Q2SkcxUm)
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583553180337)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639105851)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583553180787) (:text |conj) (:id |eA6tgzTs)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583553184077) (:text |cursor) (:id |CS9WA55m9)
-                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583553185560) (:text |:switch) (:id |uEv5nqVPw)
-                                    :id |VpM73Glwh
-                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583553186070)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583553187852) (:text |:switch) (:id |wnOXy_Njleaf)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583553188778) (:text |states) (:id |JzVf7636q)
-                                    :id |wnOXy_Nj
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639109569) (:text |>>) (:id |513iBswNco)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639110490) (:text |states) (:id |sK2fK7ZT1y)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639111967) (:text |:switch) (:id |iSehWFfsBe)
+                                    :id |rBkKefQGsc
                                 :id |suwc7ucm
                             :id |rBU-Ghz_M
                           |q $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1574442690013) (:id |DDfsK9HKwf)
@@ -4181,17 +4165,12 @@
                               |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583034130614)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036332640) (:text |comp-slider-demo) (:id |TvGCKW4H5)
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036848530)
+                                  |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639021200)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036837354) (:text |cursor) (:id |aY-B8tKQA)
-                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036851301) (:text |conj) (:id |zZ52CAPaS)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036854016) (:text |:slider) (:id |07ydrkvj)
-                                    :id |-uZL9Yp3A
-                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036857997)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036838156) (:text |states) (:id |sStOVPvJO)
-                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036860449) (:text |:slider) (:id |9T9v9jsp)
-                                    :id |ysTZBEsb_
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639021738) (:text |>>) (:id |o4cewVGHZ)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639024468) (:text |states) (:id |yGqcYqykt)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639026569) (:text |:slider) (:id |BcDGzKSxT)
+                                    :id |w7d3Lp4f5
                                 :id |TuMxJoiQZ
                             :id |Fi4G19kc
                           |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1574442621975) (:text |case) (:id |kAeLM_-X0)
@@ -4207,17 +4186,12 @@
                               |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583034130614)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040763393) (:text |comp-points-demo) (:id |TvGCKW4H5)
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036848530)
+                                  |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639077392)
                                     :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036837354) (:text |cursor) (:id |aY-B8tKQA)
-                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036851301) (:text |conj) (:id |zZ52CAPaS)
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040765822) (:text |:points) (:id |07ydrkvj)
-                                    :id |-uZL9Yp3A
-                                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036857997)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036838156) (:text |states) (:id |sStOVPvJO)
-                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040767937) (:text |:points) (:id |9T9v9jsp)
-                                    :id |ysTZBEsb_
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639079281) (:text |>>) (:id |sMR-6jcpoo)
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639080208) (:text |states) (:id |w9l5rpnKpR)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639114268) (:text |:points) (:id |0R2Q7w1e9x)
+                                    :id |cVDkH-Lnz
                                 :id |TuMxJoiQZ
                             :id |6TkcSxsv
                   |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036827332) (:text |let) (:id |IMC95h1tR)
@@ -4248,7 +4222,6 @@
               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583553190812) (:text |comp-switch-demo) (:id |kw0dudkmV)
               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583553190812)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583553193933) (:text |cursor) (:id |TNWq8W_IU)
                   |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583553196087) (:text |states) (:id |HY4K9pya)
                 :id |iSSHPSPw0
               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583553740186)
@@ -4405,6 +4378,15 @@
                                 :id |HjqUjvmMl
                             :id |IrZXTM0gf
                         :id |Z9iM2MTI3
+                      |D $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639119568)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639121249) (:text |cursor) (:id |92eyX-BrS4leaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639121449)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639123137) (:text |:cursor) (:id |9xg07p227A)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639124846) (:text |states) (:id |e_uqROsCMk)
+                            :id |eYMNq_tCix
+                        :id |92eyX-BrS4
                     :id |647wIdaF
                 :id |__Db0a4j
             :id |sZhxlu8kN
@@ -5651,6 +5633,14 @@
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036806368) (:text |{}) (:id |ixO8iBv4_)
                         :id |rjNgHucd
                     :id |wk5K9k5iD
+                  |yj $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639518204)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639519390) (:text |:cursor) (:id |EVmlfUSauleaf)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639519989)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639519838) (:text |[]) (:id |Pe0AGf8Ih0)
+                        :id |nNFZ6I39Cc
+                    :id |EVmlfUSau
         :proc $ {} (:type :expr) (:time 1499755354983) (:id |rkmjesdF9Trb) (:data $ {})
       |phlox.app.main $ {}
         :ns $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1548266580449) (:id |D4DqluvTAk)
@@ -5995,7 +5985,6 @@
               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583034073677)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036626512) (:text |props) (:id |yKiUwFDo)
-                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036629833) (:text |cursor) (:id |KEZA0aXo)
                   |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036630671) (:text |states) (:id |4V_RPsjUz)
                 :id |dhxf3bBl_
               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036898999)
@@ -6539,20 +6528,35 @@
                                 :id |NzAZf3gtX
                             :id |r19U0kpp
                         :id |CxVENzt9J
-                      |D $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036956984)
+                      |f $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038664195)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036961396) (:text |value) (:id |69EEE_0Dhleaf)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038438996)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038665013) (:text |fill) (:id |MkKc1RQSleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038665268)
                             :data $ {}
-                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036961666)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038665549) (:text |or) (:id |ffsVBwdu)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038666176)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036962947) (:text |:value) (:id |zsoXALD6F)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036963581) (:text |props) (:id |h94Lmcqv3)
-                                :id |eMbalS02L
-                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038439555) (:text |or) (:id |rL6NX9IS)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038440291) (:text |1) (:id |ovyT0HLZW)
-                            :id |hqHLLZi8i
-                        :id |69EEE_0Dh
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038666176) (:text |hslx) (:id |QGgz4a58j)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038666176) (:text |0) (:id |Xx5usBTbO)
+                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038666176) (:text |0) (:id |RUzlGUJ9H)
+                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038666176) (:text |30) (:id |cRiry5nXl)
+                                :id |mYpDLWpup
+                              |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038667612)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038668713) (:text |:fill) (:id |3SdEgo2gx)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038669463) (:text |props) (:id |yYAItYfDY)
+                                :id |PH3ipJgrt
+                            :id |mDtTK3H26
+                        :id |MkKc1RQS
+                      |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639174582)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639175527) (:text |cursor) (:id |1lLovggfkMleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639175749)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639176668) (:text |:cursor) (:id |QzowemhIxK)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639177984) (:text |states) (:id |b_h5cMk41)
+                            :id |Qybjy3ybf2
+                        :id |1lLovggfkM
                       |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583037506687)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583037508582) (:text |on-change) (:id |5qT6wis3leaf)
@@ -6576,26 +6580,24 @@
                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583556858871) (:text |0.1) (:id |A0-0_G6y)
                             :id |vgMjfBjB
                         :id |4hObe8gCd
-                      |f $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038664195)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583556625698)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038665013) (:text |fill) (:id |MkKc1RQSleaf)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038665268)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583556630412) (:text |round?) (:id |z-Q7o7Xsoleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583556630770)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038665549) (:text |or) (:id |ffsVBwdu)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038666176)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038666176) (:text |hslx) (:id |QGgz4a58j)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038666176) (:text |0) (:id |Xx5usBTbO)
-                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038666176) (:text |0) (:id |RUzlGUJ9H)
-                                  |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038666176) (:text |30) (:id |cRiry5nXl)
-                                :id |mYpDLWpup
-                              |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038667612)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038668713) (:text |:fill) (:id |3SdEgo2gx)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038669463) (:text |props) (:id |yYAItYfDY)
-                                :id |PH3ipJgrt
-                            :id |mDtTK3H26
-                        :id |MkKc1RQS
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583556634689) (:text |:round?) (:id |8DvgCUPxb)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583556636388) (:text |props) (:id |GrbnwSEKB)
+                            :id |HHJ2reg_O
+                        :id |z-Q7o7Xso
+                      |X $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583047615110)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583047616610) (:text |title) (:id |dlm2yVPwleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583047618351)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583047620017) (:text |:title) (:id |-D1xoX1nW)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583047620830) (:text |props) (:id |kNpbVt4u)
+                            :id |QvXwRX49f
+                        :id |dlm2yVPw
                       |h $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038664195)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038740763) (:text |color) (:id |MkKc1RQSleaf)
@@ -6616,30 +6618,30 @@
                                 :id |PH3ipJgrt
                             :id |mDtTK3H26
                         :id |oQnmzsGUR
-                      |X $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583047615110)
+                      |D $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036956984)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583047616610) (:text |title) (:id |dlm2yVPwleaf)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583047618351)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036961396) (:text |value) (:id |69EEE_0Dhleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038438996)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583047620017) (:text |:title) (:id |-D1xoX1nW)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583047620830) (:text |props) (:id |kNpbVt4u)
-                            :id |QvXwRX49f
-                        :id |dlm2yVPw
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583556625698)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583556630412) (:text |round?) (:id |z-Q7o7Xsoleaf)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583556630770)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583556634689) (:text |:round?) (:id |8DvgCUPxb)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583556636388) (:text |props) (:id |GrbnwSEKB)
-                            :id |HHJ2reg_O
-                        :id |z-Q7o7Xso
+                              |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036961666)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036962947) (:text |:value) (:id |zsoXALD6F)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036963581) (:text |props) (:id |h94Lmcqv3)
+                                :id |eMbalS02L
+                              |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038439555) (:text |or) (:id |rL6NX9IS)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038440291) (:text |1) (:id |ovyT0HLZW)
+                            :id |hqHLLZi8i
+                        :id |69EEE_0Dh
                     :id |qTjktpUTb
                 :id |4DxOabb6F
               |t $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038501671)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038520205) (:text |dev-check) (:id |7NOI_I3eleaf)
-                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038523046) (:text |cursor) (:id |8X0PoS-k)
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639169906)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639171241) (:text |:cursor) (:id |8X0PoS-k)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639172416) (:text |states) (:id |esrS5verOK)
+                    :id |NBV05Tt7yv
                   |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584552888814) (:text |lilac-cursor) (:id |fgnz4e9vdK)
                 :id |7NOI_I3e
               |u $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583038501671)
@@ -8393,7 +8395,6 @@
               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583040418706)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040424482) (:text |props) (:id |4K-QWBOcD)
-                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040514467) (:text |cursor) (:id |9kYtk3fk9)
                   |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583040515234) (:text |states) (:id |tckfCA1n7)
                 :id |CThqMNHMY
               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583040517813)
@@ -8995,12 +8996,25 @@
                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583041550679) (:text |3) (:id |57odigA3X)
                             :id |GrC_1w50j
                         :id |Jm0rrIVNz
+                      |D $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639341403)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639342921) (:text |cursor) (:id |axLL3rVnBleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639343228)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639345010) (:text |:cursor) (:id |8DkkW5MqM0)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639346104) (:text |states) (:id |cy2t3Fhox)
+                            :id |Xvufj9a_3
+                        :id |axLL3rVnB
                     :id |WjSYm4E7b
                 :id |QB2omY-z
               |t $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583043081994)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583043081994) (:text |dev-check) (:id |REA6ZwiAR)
-                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583043081994) (:text |cursor) (:id |asTuPcxhl)
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639331329)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639332696) (:text |:cursor) (:id |asTuPcxhl)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639333766) (:text |states) (:id |NovnZfNPln)
+                    :id |Z-0jbAlQiD
                   |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584552902442) (:text |lilac-cursor) (:id |PjEohTXvkA)
                 :id |mEOhe_b9u
               |u $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583043089620)
@@ -9159,6 +9173,7 @@
                     |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1573356355436) (:id |wt5cup8kOO)
                       :data $ {}
                         |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573356356578) (:text |[]) (:id |QV31dWY5iW)
+                        |yr $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639145537) (:text |>>) (:id |sbEBuxeZRo)
                         |s $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1581850032842) (:text |g) (:id |p6bybKMg)
                         |yT $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573974254119) (:text |container) (:id |_pYCrKPUDN)
                         |x $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573974179009) (:text |circle) (:id |YXhIPtW-10)
@@ -9186,7 +9201,6 @@
               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036332993) (:text |comp-slider-demo) (:id |j4odfxELW)
               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036332993)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036841218) (:text |cursor) (:id |XML2yM3n)
                   |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036841953) (:text |states) (:id |pOwdlbdCe)
                 :id |nEA23zr15
               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583037607799)
@@ -9251,15 +9265,10 @@
                             :id |Qwt62Lre
                           |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036871466)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036872179) (:text |conj) (:id |ywiAvGp6X)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036873166) (:text |cursor) (:id |tETJbbhgU)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639190202) (:text |>>) (:id |ywiAvGp6X)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639192919) (:text |states) (:id |tETJbbhgU)
                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036888602) (:text |:a) (:id |kuCS0YX_E)
                             :id |5tonY0-_
-                          |f $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036883666)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036886935) (:text |:a) (:id |XBDCK_IcW)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036890384) (:text |states) (:id |jZ_DXcpW-)
-                            :id |xCV0cY3zu
                         :id |ONPyDLuS
                       |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036374102) (:text |container) (:id |f2Xhmlw7)
                       |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036374486)
@@ -9339,15 +9348,10 @@
                             :id |Qwt62Lre
                           |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036871466)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036872179) (:text |conj) (:id |ywiAvGp6X)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036873166) (:text |cursor) (:id |tETJbbhgU)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639199519) (:text |>>) (:id |ywiAvGp6X)
                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038358180) (:text |:b) (:id |kuCS0YX_E)
+                              |b $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639201201) (:text |states) (:id |JBu6NT19M)
                             :id |5tonY0-_
-                          |f $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036883666)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038458347) (:text |:b) (:id |XBDCK_IcW)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036890384) (:text |states) (:id |jZ_DXcpW-)
-                            :id |xCV0cY3zu
                         :id |0PWANb3k
                       |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036337469)
                         :data $ {}
@@ -9429,15 +9433,10 @@
                             :id |Qwt62Lre
                           |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036871466)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036872179) (:text |conj) (:id |ywiAvGp6X)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036873166) (:text |cursor) (:id |tETJbbhgU)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639206903) (:text |>>) (:id |ywiAvGp6X)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639208852) (:text |states) (:id |tETJbbhgU)
                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038697331) (:text |:c) (:id |kuCS0YX_E)
                             :id |5tonY0-_
-                          |f $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036883666)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583038698729) (:text |:c) (:id |XBDCK_IcW)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036890384) (:text |states) (:id |jZ_DXcpW-)
-                            :id |xCV0cY3zu
                         :id |w8ce8i_v
                       |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036337469)
                         :data $ {}
@@ -9502,15 +9501,10 @@
                             :id |Qwt62Lre
                           |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036871466)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036872179) (:text |conj) (:id |ywiAvGp6X)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036873166) (:text |cursor) (:id |tETJbbhgU)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639212828) (:text |>>) (:id |ywiAvGp6X)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639215093) (:text |states) (:id |tETJbbhgU)
                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583557118015) (:text |:d) (:id |kuCS0YX_E)
                             :id |5tonY0-_
-                          |f $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036883666)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583557119598) (:text |:d) (:id |XBDCK_IcW)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036890384) (:text |states) (:id |jZ_DXcpW-)
-                            :id |xCV0cY3zu
                         :id |rgM8im-o
                       |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036337469)
                         :data $ {}
@@ -9575,15 +9569,10 @@
                             :id |Qwt62Lre
                           |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036871466)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036872179) (:text |conj) (:id |ywiAvGp6X)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036873166) (:text |cursor) (:id |tETJbbhgU)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639219383) (:text |>>) (:id |ywiAvGp6X)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639221383) (:text |states) (:id |tETJbbhgU)
                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583557118015) (:text |:e) (:id |kuCS0YX_E)
                             :id |5tonY0-_
-                          |f $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036883666)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583557119598) (:text |:e) (:id |XBDCK_IcW)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036890384) (:text |states) (:id |jZ_DXcpW-)
-                            :id |xCV0cY3zu
                         :id |zT-0x_W14
                       |y $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036337469)
                         :data $ {}
@@ -9648,15 +9637,10 @@
                             :id |Qwt62Lre
                           |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036871466)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036872179) (:text |conj) (:id |ywiAvGp6X)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036873166) (:text |cursor) (:id |tETJbbhgU)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639226037) (:text |>>) (:id |ywiAvGp6X)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639227729) (:text |states) (:id |tETJbbhgU)
                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583557118015) (:text |:f) (:id |kuCS0YX_E)
                             :id |5tonY0-_
-                          |f $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583036883666)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583557119598) (:text |:f) (:id |XBDCK_IcW)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583036890384) (:text |states) (:id |jZ_DXcpW-)
-                            :id |xCV0cY3zu
                         :id |2bxDdbqH
                     :id |HIQ0Ptab_
                   |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583037608516) (:text |let) (:id |OUw9_J_b)
@@ -9709,6 +9693,15 @@
                                 :id |IIYjHeYO
                             :id |ApT2yMPPF
                         :id |mzf7zyKNH
+                      |D $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639044758)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639046483) (:text |cursor) (:id |OPhwvISDhnleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584639047073)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639052220) (:text |:cursor) (:id |WB5J1Ri2S8)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584639050082) (:text |states) (:id |p01__P38V)
+                            :id |Wo8jRTdrw
+                        :id |OPhwvISDhn
                     :id |EKMaMFdR9
                 :id |eYn5Gv5Kw
             :id |R8PEMtIfm
@@ -9918,6 +9911,62 @@
                     |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573923333756) (:text |[]) (:id |_D9Y9DhtO_)
                     |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1573923338886) (:text |phlox.core) (:id |e1txgneT1)
         :defs $ {}
+          |>> $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584638878237)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638878237) (:text |defn) (:id |L0cxCXQ-hp)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638878237) (:text |>>) (:id |HcjPXy5FsH)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584638878237)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638883053) (:text |states) (:id |2NXTdsK6xM)
+                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638885519) (:text |k) (:id |ZZ4QOeQg3)
+                :id |Ar1rQ0-n_H
+              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584638924756)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584638901835)
+                    :data $ {}
+                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638903075) (:text |assoc) (:id |7gzpVGdGD)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638905152) (:text |:cursor) (:id |WQLlRtmXPN)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584638906512)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638907531) (:text |conj) (:id |r5U7mgtHCi)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638919019) (:text |k) (:id |K4t2XWrDi)
+                          |f $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638942436) (:text |parent-cursor) (:id |G22gfrc7e8)
+                        :id |P-dCqih47
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638955985) (:text |branch) (:id |ykuOjeamlv)
+                    :id |GaMoCk8kJe
+                  |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638925342) (:text |let) (:id |2XkOjyEnDW)
+                  |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584638925555)
+                    :data $ {}
+                      |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584638925700)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638929693) (:text |parent-cursor) (:id |zgMaLdhoWj)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584638934787)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638934787) (:text |or) (:id |G4Scsufe7z)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584638934787)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638934787) (:text |:cursor) (:id |c2s_BaSGBl)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638966518) (:text |states) (:id |gGbc9e6oxN)
+                                :id |YVWlqHrIA-
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584638936937)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638934787) (:text |[]) (:id |TDZcth5wgO)
+                                :id |z4_1rNfa9r
+                            :id |0ZH-BiQDNM
+                        :id |yutriSaJp5
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584638950216)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638951194) (:text |branch) (:id |5XcxR1fINleaf)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584638954118)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638954118) (:text |get) (:id |VOgK-rtbLY)
+                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638954118) (:text |states) (:id |nEuIhGNviq)
+                              |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584638954118) (:text |k) (:id |QIDXsER_al)
+                            :id |iseTRdIUSZ
+                        :id |5XcxR1fIN
+                    :id |V6b7YpYmhY
+                :id |rIUAsfsvlM
+            :id |-QNor--2Jr
           |lilac-begin-fill $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1584552965892)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1584552965892) (:text |def) (:id |yN3Epw8bbj)

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.1.11-a2"
+{:version "0.2.0-a1"
  :group-id "quamolit"
  :artifact-id "phlox"
  :skip-tag true

--- a/src/phlox/app/comp/slider_demo.cljs
+++ b/src/phlox/app/comp/slider_demo.cljs
@@ -2,33 +2,31 @@
 (ns phlox.app.comp.slider-demo
   (:require [phlox.core
              :refer
-             [defcomp g hslx rect circle text container graphics create-list]]
+             [defcomp g hslx rect circle text container graphics create-list >>]]
             [phlox.comp.slider :refer [comp-slider]]))
 
 (defcomp
  comp-slider-demo
- (cursor states)
- (let [state (or (:data states) {:a 40, :b 20, :c 10, :d 10, :e 10, :f 10})]
+ (states)
+ (let [cursor (:cursor states)
+       state (or (:data states) {:a 40, :b 20, :c 10, :d 10, :e 10, :f 10})]
    (container
     {:position [300 100]}
     (comp-slider
-     (conj cursor :a)
-     (:a states)
+     (>> states :a)
      {:value (:a state),
       :unit 1,
       :position [20 0],
       :on-change (fn [value d!] (d! cursor (assoc state :a value)))})
     (comp-slider
-     (conj cursor :b)
-     (:b states)
+     (>> states :b)
      {:value (:b state),
       :title "Refine",
       :unit 0.1,
       :position [20 60],
       :on-change (fn [value d!] (d! cursor (assoc state :b value)))})
     (comp-slider
-     (conj cursor :c)
-     (:c states)
+     (>> states :c)
      {:value (:c state),
       :unit 10,
       :position [20 120],
@@ -36,24 +34,21 @@
       :color (hslx 200 90 30),
       :on-change (fn [value d!] (d! cursor (assoc state :c value)))})
     (comp-slider
-     (conj cursor :d)
-     (:d states)
+     (>> states :d)
      {:value (:d state),
       :position [20 180],
       :on-change (fn [value d!] (d! cursor (assoc state :d value))),
       :title "Round",
       :round? true})
     (comp-slider
-     (conj cursor :e)
-     (:e states)
+     (>> states :e)
      {:value (:e state),
       :position [20 240],
       :on-change (fn [value d!] (d! cursor (assoc state :e value))),
       :title "min 10",
       :min 10})
     (comp-slider
-     (conj cursor :f)
-     (:f states)
+     (>> states :f)
      {:value (:f state),
       :position [20 300],
       :on-change (fn [value d!] (d! cursor (assoc state :f value))),

--- a/src/phlox/app/container.cljs
+++ b/src/phlox/app/container.cljs
@@ -2,7 +2,7 @@
 (ns phlox.app.container
   (:require [phlox.core
              :refer
-             [defcomp g hslx rect circle text container graphics create-list]]
+             [defcomp g hslx rect circle text container graphics create-list >>]]
             [phlox.app.comp.drafts :refer [comp-drafts]]
             [phlox.app.comp.keyboard :refer [comp-keyboard]]
             [phlox.comp.button :refer [comp-button]]
@@ -71,24 +71,22 @@
 
 (defcomp
  comp-points-demo
- (cursor states)
- (let [state (or (:data states) {:p1 [0 0], :p2 [0 0], :p3 [0 0], :p4 [0 0]})]
+ (states)
+ (let [cursor (:cursor states)
+       state (or (:data states) {:p1 [0 0], :p2 [0 0], :p3 [0 0], :p4 [0 0]})]
    (container
     {:position [300 200]}
     (comp-drag-point
-     (conj cursor :p1)
-     (:p1 states)
+     (>> states :p1)
      {:position (:p1 state),
       :on-change (fn [position d!] (d! cursor (assoc state :p1 position)))})
     (comp-drag-point
-     (conj cursor :p2)
-     (:p2 states)
+     (>> states :p2)
      {:position (:p2 state),
       :unit 2,
       :on-change (fn [position d!] (d! cursor (assoc state :p2 position)))})
     (comp-drag-point
-     (conj cursor :p3)
-     (:p3 states)
+     (>> states :p3)
      {:position (:p3 state),
       :unit 0.4,
       :radius 6,
@@ -96,16 +94,15 @@
       :color (hslx 0 0 50),
       :on-change (fn [position d!] (d! cursor (assoc state :p3 position)))})
     (comp-drag-point
-     (conj cursor :p4)
-     (:p4 states)
+     (>> states :p4)
      {:position (:p4 state),
       :title "base",
       :on-change (fn [position d!] (d! cursor (assoc state :p4 position)))}))))
 
 (defcomp
  comp-switch-demo
- (cursor states)
- (let [state (or (:data states) {:value false})]
+ (states)
+ (let [cursor (:cursor states), state (or (:data states) {:value false})]
    (container
     {:position [300 300]}
     (comp-switch
@@ -163,9 +160,9 @@
       :gradients (comp-gradients)
       :keyboard (comp-keyboard (:keyboard-on? store) (:counted store))
       :buttons (comp-buttons)
-      :slider (comp-slider-demo (conj cursor :slider) (:slider states))
-      :points (comp-points-demo (conj cursor :points) (:points states))
-      :switch (comp-switch-demo (conj cursor :switch) (:switch states))
+      :slider (comp-slider-demo (>> states :slider))
+      :points (comp-points-demo (>> states :points))
+      :switch (comp-switch-demo (>> states :switch))
       (text
        {:text "Unknown",
         :style {:fill (hslx 0 100 80), :font-size 12, :font-family "Helvetica"}})))))

--- a/src/phlox/app/schema.cljs
+++ b/src/phlox/app/schema.cljs
@@ -1,4 +1,4 @@
 
 (ns phlox.app.schema )
 
-(def store {:tab :drafts, :x 0, :keyboard-on? false, :counted 0, :states {}})
+(def store {:tab :drafts, :x 0, :keyboard-on? false, :counted 0, :states {}, :cursor []})

--- a/src/phlox/comp/drag_point.cljs
+++ b/src/phlox/comp/drag_point.cljs
@@ -35,10 +35,11 @@
     :on-change (fn+)}
    {:check-keys? true}))
 
-(defn comp-drag-point [cursor states props]
-  (dev-check cursor lilac-cursor)
+(defn comp-drag-point [states props]
+  (dev-check (:cursor states) lilac-cursor)
   (dev-check props lilac-drag-point)
-  (let [state (or (:data states) {:dragging? false, :x0 [0 0]})
+  (let [cursor (:cursor states)
+        state (or (:data states) {:dragging? false, :x0 [0 0]})
         unit (or (:unit props) 1)
         radius (or (:radius props) 3)
         color (or (:color props) (hslx 0 0 100))

--- a/src/phlox/comp/slider.cljs
+++ b/src/phlox/comp/slider.cljs
@@ -39,10 +39,11 @@
 
 (defcomp
  comp-slider
- (cursor states props)
- (dev-check cursor lilac-cursor)
+ (states props)
+ (dev-check (:cursor states) lilac-cursor)
  (dev-check props lilac-slider)
  (let [value (or (:value props) 1)
+       cursor (:cursor states)
        state (or (:data states) {:v0 value, :x0 0, :dragging? false})
        title (:title props)
        unit (or (:unit props) 0.1)

--- a/src/phlox/core.cljs
+++ b/src/phlox/core.cljs
@@ -41,6 +41,10 @@
 
 (defonce *tree-element (atom nil))
 
+(defn >> [states k]
+  (let [parent-cursor (or (:cursor states) []), branch (get states k)]
+    (assoc branch :cursor (conj parent-cursor k))))
+
 (defn create-element [tag props children]
   {:name tag,
    :phlox-node :element,


### PR DESCRIPTION
Syntax sugar, which is a function, `>>` is added. Instead of writing `(comp-a (conj cursor :k) (:k states) b c)` for branching states, now `(comp-a (>> states :k) b c)` is okay. It's supposed to be much shorter and would open new oppotuenities of changes.
