### PR TITLE
break to simplify complex utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,17 @@ To interact with text input:
   (fn [result] (println "got:" result)))
 ```
 
+### Complex number
+
+`phlox.complex` contains several util functions to work with complex numbers like `[x y]`.
+
+- `add`, adds two complex numbers
+- `minus`, adds one to another
+- `times`, mutiply two complex numbers
+- `rebase`, actualy "divide", renamed since naming collision.
+- `divide-by`, divide by scalar number `x`.
+- `rand-point`, returns a random `[x y]`, takes 1 or 2 arguments
+
 ### Workflow
 
 Workflow https://github.com/Quamolit/phlox-workflow

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -3344,96 +3344,6 @@
             |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |phlox.complex) (:id |7Z3xw28WbC)
           :id |h0iOMvwqyS
         :defs $ {}
-          |multiply $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |defn) (:id |56iNPKowhc)
-              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |multiply) (:id |z5SQldHeNJ)
-              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                :data $ {}
-                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |VePnGAfGlg)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |sluNrZFaRD)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |xzLSmWNZjn)
-                    :id |ZieLknIMkq
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |QJXl5FiAeQ)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |1rcxm2NHbo)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |qPUHbdQySji)
-                    :id |cHQN3aKDcp
-                :id |BwVLjZ8ST_
-              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |6AfFFDDol-R)
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |-) (:id |0aaDrYCKkUl)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |*) (:id |-9ci6qm1sqZ)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |iQnU7aDf2ct)
-                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |ReElnvA0a9t)
-                        :id |VHBjU4Ciu0o
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |*) (:id |4YtlkzTlFq8)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |34c5W2MWIqI)
-                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |Rh5ySDfCXG6)
-                        :id |dlkQr9bNuO6
-                    :id |8QQnbfILD7g
-                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |+) (:id |TqumHbCAdQf)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |*) (:id |2u100wK7bTn)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |zvg3cbqXzaq)
-                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |xZeXUBlSoSw)
-                        :id |JFGE-ooFSzJ
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |*) (:id |ymyL0bpGJcO)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |bJd0pUbBZ6F)
-                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |XeqNrNDuWkn)
-                        :id |QNiQtRCWW8f
-                    :id |mSsA_QAN2I_
-                :id |_zV6iXQzteV
-            :id |gqmhwIqosm
-          |divide-x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |defn) (:id |X27vODd6fmz)
-              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |divide-x) (:id |gPlBGLV9ino)
-              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |point) (:id |Lco9fHEYTkW)
-                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |HRTnGKvZ0Ls)
-                :id |e748vEDUbYc
-              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |QMo6E2IFstm)
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |/) (:id |e48MRhcquRd)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |first) (:id |PD0Mr4NWgHf)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |point) (:id |QfDbqPFkNd8)
-                        :id |C5jkYlNyHmp
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |V4Z6idPknSp)
-                    :id |aK7S6hzwNjT
-                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |/) (:id |Y9LUyyvXEI9)
-                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
-                        :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |peek) (:id |ZsSu0Qe_QXW)
-                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |point) (:id |gM3yrwR_G2V)
-                        :id |yrejzX5Kd0j
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |G7KG6HIPeI_)
-                    :id |hbHolTvPiyC
-                :id |q7BBYKMPGD2
-            :id |NZRywTpMrua
           |rand-point $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720493056)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |defn$) (:id |bBjjj6LUC3)
@@ -3464,84 +3374,76 @@
                       |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720493056)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |-) (:id |RdMuU5VBFkX)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720493056)
+                          |f $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593533964648) (:text |n) (:id |qAiLQWCTn)
+                          |p $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593533997991)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |js/Math.round) (:id |DOzWcDdikoe)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720493056)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593534000559) (:text |rand-int) (:id |5ch6oqEug)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593534001041)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |*) (:id |Kee5zYvFwW6)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |0.2) (:id |Huv82Qsv4pp)
-                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |n) (:id |YlXFHi55bwS)
-                                :id |bBN12a4ZsG5
-                            :id |bxjKVNMOqdL
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720493056)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |rand-int) (:id |gPw--ZyymcV)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |n) (:id |CVRIYH3Cf3M)
-                            :id |AsGhKaQcKK7
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593534001442) (:text |*) (:id |BXjsT5_pCl)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593534002098) (:text |2) (:id |YpCkRvMLMJ)
+                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593534002443) (:text |n) (:id |NRvNZ7GC7B)
+                                :id |rLfRlDTsxS
+                            :id |duZlXjZvzP
                         :id |ZbR8zc0cFFq
-                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720493056)
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593533984495)
                         :data $ {}
-                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |-) (:id |CJ8r5sXjX-4)
-                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720493056)
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593533984495) (:text |-) (:id |4qvh-GGlZy)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593533986043) (:text |m) (:id |ILL1tfDGyU)
+                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593534005595)
                             :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |js/Math.round) (:id |G3R72JEZurX)
-                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720493056)
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593534007409) (:text |rand-int) (:id |pRETiwEDF)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1593534008010)
                                 :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |*) (:id |BSBXk4IjA4o)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |0.2) (:id |B_XOuXfUdXv)
-                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |m) (:id |VQ3t0liP4oP)
-                                :id |zYXBQ3ILSKf
-                            :id |03AvzF1C0Jw
-                          |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720493056)
-                            :data $ {}
-                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |rand-int) (:id |PuA8lsD_ft2)
-                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720493056) (:text |m) (:id |F2JUWvsFbzH)
-                            :id |DiNlXUCoEGW
-                        :id |m44HRqNA6tq
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593534008476) (:text |*) (:id |ApZTyVp3B9)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593534008972) (:text |2) (:id |EKmK0wucwl)
+                                  |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593534009846) (:text |m) (:id |AO_1HQbhW)
+                                :id |YhVa9CUuLK
+                            :id |mCwwpR6dQe
+                        :id |S34p2H3OZT
                     :id |6XlMfiJdCJl
                 :id |nq3tqAC3ZL
             :id |DdfejR5jHD
-          |subtract $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+          |add $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
             :data $ {}
-              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |defn) (:id |jkZ4AXvB4Bb)
-              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |subtract) (:id |oCErhf7QI7p)
+              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |defn) (:id |ZXdc_Bltq9c)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |add) (:id |wLNk7idBbKu)
               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                 :data $ {}
                   |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |i985JPSGDEa)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |HDdzULsSR-B)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |ZCHdQ385Coj)
-                    :id |vvfqY3bes0Q
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |uWvAPBZENym)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |WJMOsQOkHsl)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |Dbp3sGQtqb-)
+                    :id |BT-yzDIeDXC
                   |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |Anf2EvoXsUQ)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |V9c_IEfyhTE)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |Q8vhdQtN4rk)
-                    :id |BsTVhhPgssN
-                :id |g6saWXFIpUG
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |_s7pO8Z1nh6)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |IVOCRsmac43)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |K1cVj6oPesZ)
+                    :id |dJsfEeTk6WZ
+                :id |J-acn7QjdP_
               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |A3jRdKI-vtY)
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |L0c7HbyVZyY)
                   |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |-) (:id |oLYdnLFTGpZ)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |iDEVx2cnXtf)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |7Nt0eafEMcT)
-                    :id |bG0OM7U6dsx
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |+) (:id |d9Si-VlA4_Q)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |bI0kk8ZNI90)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |jg-RjAxsni7)
+                    :id |-z2zuP9hPPT
                   |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |-) (:id |gq46QuCfLzC)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |BrKcIoCB-EK)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |LTJUY4LrfzU)
-                    :id |593ef7jRAnc
-                :id |auTVdgWKAAT
-            :id |gkQs1Y5ata1
-          |divide $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |+) (:id |hKZ_3YPG3ZB)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |FbbB5sJd3ya)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |Ynx3lggrfMa)
+                    :id |5KIwaqeT9Pn
+                :id |whjI2QwfphF
+            :id |kk3xkiB3v2H
+          |rebase $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |defn) (:id |iBcJ2srxs6n)
-              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |divide) (:id |2k1yzWB38VF)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |rebase) (:id |2k1yzWB38VF)
               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                 :data $ {}
                   |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
@@ -3635,43 +3537,134 @@
                         :id |3uNTtRBs3Kf
                     :id |kiqvoHnl5SS
                 :id |7_iSO1oqXb-
+              |t $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593533276084) (:text "|\"complex number division, renamed since naming collision") (:id |B7dakROtZi)
             :id |lyr41HyPbTa
-          |add $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+          |divide-by $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
             :data $ {}
-              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |defn) (:id |ZXdc_Bltq9c)
-              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |add) (:id |wLNk7idBbKu)
+              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |defn) (:id |X27vODd6fmz)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |divide-by) (:id |gPlBGLV9ino)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |point) (:id |Lco9fHEYTkW)
+                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |HRTnGKvZ0Ls)
+                :id |e748vEDUbYc
+              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |QMo6E2IFstm)
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |/) (:id |e48MRhcquRd)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |first) (:id |PD0Mr4NWgHf)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |point) (:id |QfDbqPFkNd8)
+                        :id |C5jkYlNyHmp
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |V4Z6idPknSp)
+                    :id |aK7S6hzwNjT
+                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |/) (:id |Y9LUyyvXEI9)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |peek) (:id |ZsSu0Qe_QXW)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |point) (:id |gM3yrwR_G2V)
+                        :id |yrejzX5Kd0j
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |G7KG6HIPeI_)
+                    :id |hbHolTvPiyC
+                :id |q7BBYKMPGD2
+            :id |NZRywTpMrua
+          |minus $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |defn) (:id |jkZ4AXvB4Bb)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |minus) (:id |oCErhf7QI7p)
               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                 :data $ {}
                   |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |uWvAPBZENym)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |WJMOsQOkHsl)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |Dbp3sGQtqb-)
-                    :id |BT-yzDIeDXC
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |i985JPSGDEa)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |HDdzULsSR-B)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |ZCHdQ385Coj)
+                    :id |vvfqY3bes0Q
                   |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |_s7pO8Z1nh6)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |IVOCRsmac43)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |K1cVj6oPesZ)
-                    :id |dJsfEeTk6WZ
-                :id |J-acn7QjdP_
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |Anf2EvoXsUQ)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |V9c_IEfyhTE)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |Q8vhdQtN4rk)
+                    :id |BsTVhhPgssN
+                :id |g6saWXFIpUG
               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                 :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |L0c7HbyVZyY)
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |A3jRdKI-vtY)
                   |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |+) (:id |d9Si-VlA4_Q)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |bI0kk8ZNI90)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |jg-RjAxsni7)
-                    :id |-z2zuP9hPPT
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |-) (:id |oLYdnLFTGpZ)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |iDEVx2cnXtf)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |7Nt0eafEMcT)
+                    :id |bG0OM7U6dsx
                   |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
                     :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |+) (:id |hKZ_3YPG3ZB)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |FbbB5sJd3ya)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |Ynx3lggrfMa)
-                    :id |5KIwaqeT9Pn
-                :id |whjI2QwfphF
-            :id |kk3xkiB3v2H
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |-) (:id |gq46QuCfLzC)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |BrKcIoCB-EK)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |LTJUY4LrfzU)
+                    :id |593ef7jRAnc
+                :id |auTVdgWKAAT
+            :id |gkQs1Y5ata1
+          |times $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |defn) (:id |56iNPKowhc)
+              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |times) (:id |z5SQldHeNJ)
+              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                :data $ {}
+                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |VePnGAfGlg)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |sluNrZFaRD)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |xzLSmWNZjn)
+                    :id |ZieLknIMkq
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |QJXl5FiAeQ)
+                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |1rcxm2NHbo)
+                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |qPUHbdQySji)
+                    :id |cHQN3aKDcp
+                :id |BwVLjZ8ST_
+              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |[]) (:id |6AfFFDDol-R)
+                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |-) (:id |0aaDrYCKkUl)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |*) (:id |-9ci6qm1sqZ)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |iQnU7aDf2ct)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |ReElnvA0a9t)
+                        :id |VHBjU4Ciu0o
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |*) (:id |4YtlkzTlFq8)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |34c5W2MWIqI)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |Rh5ySDfCXG6)
+                        :id |dlkQr9bNuO6
+                    :id |8QQnbfILD7g
+                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                    :data $ {}
+                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |+) (:id |TqumHbCAdQf)
+                      |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |*) (:id |2u100wK7bTn)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |a) (:id |zvg3cbqXzaq)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |y) (:id |xZeXUBlSoSw)
+                        :id |JFGE-ooFSzJ
+                      |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |*) (:id |ymyL0bpGJcO)
+                          |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |b) (:id |bJd0pUbBZ6F)
+                          |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1591720373551) (:text |x) (:id |XeqNrNDuWkn)
+                        :id |QNiQtRCWW8f
+                    :id |mSsA_QAN2I_
+                :id |_zV6iXQzteV
+            :id |gqmhwIqosm
         :proc $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1591720373551) (:data $ {}) (:id |synZ36GjGm)
       |phlox.app.config $ {}
         :ns $ {} (:type :expr) (:by |root) (:at 1527788237503) (:id |BJlrAf2TyX)
@@ -12088,13 +12081,9 @@
                 |x $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042419517)
                   :data $ {}
                     |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042419517) (:text |[]) (:id |9CKnVPOJP)
-                    |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042419517) (:text |phlox.math) (:id |h2Zp3Kg5F)
-                    |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042419517) (:text |:refer) (:id |3zdjVJ94R)
-                    |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042419517)
-                      :data $ {}
-                        |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042419517) (:text |[]) (:id |SzwvM0A2L)
-                        |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042419517) (:text |v-add) (:id |tSAWT26iM)
-                      :id |rcDvEHfxO
+                    |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593533465463) (:text |phlox.complex) (:id |h2Zp3Kg5F)
+                    |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593533466295) (:text |:as) (:id |3zdjVJ94R)
+                    |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593533469213) (:text |complex) (:id |xdwiLzNYr)
                   :id |FSQ_ZIS5K
               :id |mXMTVFJcS
           :id |mDbpFe0Vb
@@ -12261,7 +12250,7 @@
                                                                                 :id |sXVKy57aT
                                                                             :id |c3VdDelHV
                                                                         :id |lygKyeDy
-                                                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042414356) (:text |v-add) (:id |iU1n6cU1)
+                                                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1593533451052) (:text |complex/add) (:id |iU1n6cU1)
                                                                       |L $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042764122)
                                                                         :data $ {}
                                                                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042766124) (:text |:p0) (:id |BmXp5KJ34)
@@ -17906,42 +17895,6 @@
             |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042373254) (:text |phlox.math) (:id |MFCRpdZ3f)
           :id |XNWzHL2mY
         :defs $ {}
-          |v-add $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042379307)
-            :data $ {}
-              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042379307) (:text |defn) (:id |17JVGccFk)
-              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042379307) (:text |v-add) (:id |DLjuTfgn-)
-              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042379307)
-                :data $ {}
-                  |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042391287)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042392939) (:text |[]) (:id |5nMQerXP)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042394152) (:text |a) (:id |sm8IqMPq)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042394672) (:text |b) (:id |Bw7dnwX3H)
-                    :id |gTTsHeX6-
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042395988)
-                    :data $ {}
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042396390) (:text |[]) (:id |0Scigc0H)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042397678) (:text |x) (:id |PpGgBqg8)
-                      |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042398113) (:text |y) (:id |-aipwgckf)
-                    :id |kaj4ZU1Cx
-                :id |rNrAb5Cc4
-              |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042399820)
-                :data $ {}
-                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042400625) (:text |[]) (:id |BEueSOaQlleaf)
-                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042401303)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042401024) (:text |+) (:id |Jh9y_0TrJ)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042402605) (:text |a) (:id |dsZvU3-3u)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042402964) (:text |x) (:id |yR7CFuz5B)
-                    :id |KgwJT6_x
-                  |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1583042403736)
-                    :data $ {}
-                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042404655) (:text |+) (:id |3oZFDgsxsleaf)
-                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042405271) (:text |b) (:id |NVnBkIWeb)
-                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1583042406309) (:text |y) (:id |t6C-FPmiL)
-                    :id |3oZFDgsxs
-                :id |BEueSOaQl
-            :id |byf-uqdta
           |angle->radian $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1585587496640)
             :data $ {}
               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1585587499075) (:text |defn) (:id |86g2gOt6eC)

--- a/release.edn
+++ b/release.edn
@@ -1,4 +1,4 @@
-{:version "0.3.2",
+{:version "0.3.3-a1",
  :group-id "quamolit",
  :artifact-id "phlox",
  :skip-tag true,

--- a/src/phlox/comp/drag_point.cljs
+++ b/src/phlox/comp/drag_point.cljs
@@ -20,7 +20,7 @@
               vector+
               or+
               is+]]
-            [phlox.math :refer [v-add]]))
+            [phlox.complex :as complex]))
 
 (def lilac-cursor (vector+ (any+ {:some? true})))
 
@@ -62,7 +62,7 @@
                   (let [x (-> e .-data .-global .-x), y (-> e .-data .-global .-y)]
                     (let [x0 (:x0 state)]
                       (on-change
-                       (v-add
+                       (complex/add
                         (:p0 state)
                         [(* unit (- x (first x0))) (* unit (- y (peek x0)))])
                        d!))))),

--- a/src/phlox/complex.cljs
+++ b/src/phlox/complex.cljs
@@ -3,17 +3,17 @@
 
 (defn add [[a b] [x y]] [(+ a x) (+ b y)])
 
-(defn divide [[x y] [a b]]
-  (let [inverted (/ 1 (+ (* a a) (* b b)))]
-    [(* inverted (+ (* x a) (* y b))) (* inverted (- (* y a) (* x b)))]))
+(defn divide-by [point x] [(/ (first point) x) (/ (peek point) x)])
 
-(defn divide-x [point x] [(/ (first point) x) (/ (peek point) x)])
-
-(defn multiply [[a b] [x y]] [(- (* a x) (* b y)) (+ (* a y) (* b x))])
+(defn minus [[a b] [x y]] [(- a x) (- b y)])
 
 (defn rand-point
   ([n] (rand-point n n))
-  ([n m]
-   [(- (js/Math.round (* 0.2 n)) (rand-int n)) (- (js/Math.round (* 0.2 m)) (rand-int m))]))
+  ([n m] [(- n (rand-int (* 2 n))) (- m (rand-int (* 2 m)))]))
 
-(defn subtract [[a b] [x y]] [(- a x) (- b y)])
+(defn rebase [[x y] [a b]]
+  "complex number division, renamed since naming collision"
+  (let [inverted (/ 1 (+ (* a a) (* b b)))]
+    [(* inverted (+ (* x a) (* y b))) (* inverted (- (* y a) (* x b)))]))
+
+(defn times [[a b] [x y]] [(- (* a x) (* b y)) (+ (* a y) (* b x))])

--- a/src/phlox/math.cljs
+++ b/src/phlox/math.cljs
@@ -4,5 +4,3 @@
 (def radian-ratio (/ js/Math.PI 180))
 
 (defn angle->radian [x] (* x radian-ratio))
-
-(defn v-add [[a b] [x y]] [(+ a x) (+ b y)])


### PR DESCRIPTION
this is actually a breaking change on APIs that are barely used. `divide` already existed as `cljs.core/divide`, so I have to pick another name, although `rebase` is not a correct one, however I think it's more like intuitive. Also some function names are changed.

Better to look into https://github.com/alanforr/complex in the future...